### PR TITLE
Add generic ObjectPool with Unity wrappers and sample usage

### DIFF
--- a/Runtime/Pooling/ComponentPool.cs
+++ b/Runtime/Pooling/ComponentPool.cs
@@ -1,0 +1,91 @@
+using System;
+using UnityEngine;
+
+namespace UnityUtilities.Pooling
+{
+    /// <summary>
+    /// Unity-specific pool for component instances.
+    /// </summary>
+    /// <typeparam name="TComponent">Component type to pool.</typeparam>
+    public sealed class ComponentPool<TComponent> where TComponent : Component
+    {
+        private readonly GameObjectPool _gameObjectPool;
+
+        /// <summary>
+        /// Creates a component pool using a component prefab.
+        /// </summary>
+        /// <param name="prefab">Component prefab to instantiate.</param>
+        /// <param name="initialCapacity">Number of objects to prewarm.</param>
+        /// <param name="maxCapacity">Maximum inactive pooled instances.</param>
+        /// <param name="inactiveParent">Optional parent transform for inactive pooled objects.</param>
+        /// <param name="activateOnGet">Whether instances activate on get.</param>
+        /// <param name="deactivateOnReturn">Whether instances deactivate on return.</param>
+        public ComponentPool(
+            TComponent prefab,
+            int initialCapacity = 0,
+            int maxCapacity = 128,
+            Transform inactiveParent = null,
+            bool activateOnGet = true,
+            bool deactivateOnReturn = true)
+        {
+            if (prefab == null)
+            {
+                throw new ArgumentNullException(nameof(prefab));
+            }
+
+            _gameObjectPool = new GameObjectPool(
+                prefab.gameObject,
+                initialCapacity,
+                maxCapacity,
+                inactiveParent,
+                activateOnGet,
+                deactivateOnReturn);
+        }
+
+        /// <summary>
+        /// Gets the count of inactive pooled instances.
+        /// </summary>
+        public int InactiveCount => _gameObjectPool.InactiveCount;
+
+        /// <summary>
+        /// Spawns a pooled component instance.
+        /// </summary>
+        /// <param name="position">Optional world position.</param>
+        /// <param name="rotation">Optional world rotation.</param>
+        /// <param name="parent">Optional active parent transform.</param>
+        /// <returns>Pooled component instance.</returns>
+        public TComponent Spawn(Vector3? position = null, Quaternion? rotation = null, Transform parent = null)
+        {
+            GameObject go = _gameObjectPool.Spawn(position, rotation, parent);
+            return go.GetComponent<TComponent>();
+        }
+
+        /// <summary>
+        /// Despawns a pooled component instance.
+        /// </summary>
+        /// <param name="instance">Component instance to return.</param>
+        /// <returns>True when successfully returned.</returns>
+        public bool Despawn(TComponent instance)
+        {
+            return instance != null && _gameObjectPool.Despawn(instance.gameObject);
+        }
+
+        /// <summary>
+        /// Prewarms the pool.
+        /// </summary>
+        /// <param name="count">Count to prewarm.</param>
+        public void Prewarm(int count)
+        {
+            _gameObjectPool.Prewarm(count);
+        }
+
+        /// <summary>
+        /// Clears pooled instances.
+        /// </summary>
+        /// <param name="destroyAll">When true, also destroys tracked active instances.</param>
+        public void Clear(bool destroyAll = false)
+        {
+            _gameObjectPool.Clear(destroyAll);
+        }
+    }
+}

--- a/Runtime/Pooling/GameObjectPool.cs
+++ b/Runtime/Pooling/GameObjectPool.cs
@@ -1,0 +1,152 @@
+using System;
+using UnityEngine;
+
+namespace UnityUtilities.Pooling
+{
+    /// <summary>
+    /// Unity-specific pool for <see cref="GameObject"/> instances.
+    /// </summary>
+    public sealed class GameObjectPool
+    {
+        private readonly ObjectPool<GameObject> _pool;
+        private readonly GameObject _prefab;
+        private readonly Transform _inactiveParent;
+        private readonly bool _activateOnGet;
+        private readonly bool _deactivateOnReturn;
+
+        /// <summary>
+        /// Creates a pool for the provided prefab.
+        /// </summary>
+        /// <param name="prefab">Prefab used to create instances.</param>
+        /// <param name="initialCapacity">Number of instances to prewarm.</param>
+        /// <param name="maxCapacity">Maximum inactive pooled instances.</param>
+        /// <param name="inactiveParent">Optional parent transform used for inactive returned objects.</param>
+        /// <param name="activateOnGet">Whether to activate objects when spawned.</param>
+        /// <param name="deactivateOnReturn">Whether to deactivate objects when despawned.</param>
+        public GameObjectPool(
+            GameObject prefab,
+            int initialCapacity = 0,
+            int maxCapacity = 128,
+            Transform inactiveParent = null,
+            bool activateOnGet = true,
+            bool deactivateOnReturn = true)
+        {
+            if (prefab == null)
+            {
+                throw new ArgumentNullException(nameof(prefab));
+            }
+
+            _prefab = prefab;
+            _inactiveParent = inactiveParent;
+            _activateOnGet = activateOnGet;
+            _deactivateOnReturn = deactivateOnReturn;
+
+            _pool = new ObjectPool<GameObject>(
+                CreateInstance,
+                OnGet,
+                OnReturn,
+                OnDestroy,
+                IsValid,
+                initialCapacity,
+                maxCapacity);
+        }
+
+        /// <summary>
+        /// Gets the amount of inactive pooled instances.
+        /// </summary>
+        public int InactiveCount => _pool.InactiveCount;
+
+        /// <summary>
+        /// Spawns a pooled object.
+        /// </summary>
+        /// <param name="position">Optional spawn position.</param>
+        /// <param name="rotation">Optional spawn rotation.</param>
+        /// <param name="parent">Optional parent transform for the active object.</param>
+        /// <returns>The pooled instance.</returns>
+        public GameObject Spawn(Vector3? position = null, Quaternion? rotation = null, Transform parent = null)
+        {
+            GameObject instance = _pool.Get();
+
+            if (parent != null)
+            {
+                instance.transform.SetParent(parent, false);
+            }
+
+            if (position.HasValue)
+            {
+                instance.transform.position = position.Value;
+            }
+
+            if (rotation.HasValue)
+            {
+                instance.transform.rotation = rotation.Value;
+            }
+
+            return instance;
+        }
+
+        /// <summary>
+        /// Returns an instance to the pool.
+        /// </summary>
+        /// <param name="instance">Instance to despawn.</param>
+        /// <returns>True if returned to pool.</returns>
+        public bool Despawn(GameObject instance)
+        {
+            return _pool.Return(instance);
+        }
+
+        /// <summary>
+        /// Prewarms the pool.
+        /// </summary>
+        /// <param name="count">Count to prewarm.</param>
+        public void Prewarm(int count)
+        {
+            _pool.Prewarm(count);
+        }
+
+        /// <summary>
+        /// Clears pooled instances.
+        /// </summary>
+        /// <param name="destroyAll">When true, also destroys any tracked active objects.</param>
+        public void Clear(bool destroyAll = false)
+        {
+            _pool.Clear(destroyAll);
+        }
+
+        private GameObject CreateInstance()
+        {
+            return UnityEngine.Object.Instantiate(_prefab);
+        }
+
+        private void OnGet(GameObject instance)
+        {
+            if (_activateOnGet && !instance.activeSelf)
+            {
+                instance.SetActive(true);
+            }
+        }
+
+        private void OnReturn(GameObject instance)
+        {
+            if (_inactiveParent != null)
+            {
+                instance.transform.SetParent(_inactiveParent, false);
+            }
+
+            if (_deactivateOnReturn && instance.activeSelf)
+            {
+                instance.SetActive(false);
+            }
+        }
+
+        private void OnDestroy(GameObject instance)
+        {
+            UnityEngine.Object.Destroy(instance);
+        }
+
+        private static bool IsValid(GameObject instance)
+        {
+            return instance != null;
+        }
+    }
+}

--- a/Runtime/Pooling/GameObjectPoolBehaviour.cs
+++ b/Runtime/Pooling/GameObjectPoolBehaviour.cs
@@ -1,0 +1,125 @@
+using UnityEngine;
+
+namespace UnityUtilities.Pooling
+{
+    /// <summary>
+    /// Inspector-driven <see cref="GameObject"/> pool component.
+    /// </summary>
+    public sealed class GameObjectPoolBehaviour : MonoBehaviour
+    {
+        [Header("Pool")]
+        [SerializeField] private GameObject prefab;
+        [SerializeField] [Min(0)] private int initialCapacity = 8;
+        [SerializeField] [Min(1)] private int maxCapacity = 64;
+        [SerializeField] private Transform inactiveParent;
+        [SerializeField] private bool prewarmOnAwake = true;
+
+        [Header("Activation")]
+        [SerializeField] private bool activateOnSpawn = true;
+        [SerializeField] private bool deactivateOnDespawn = true;
+
+        private GameObjectPool _pool;
+
+        /// <summary>
+        /// Gets whether this pool has been initialized.
+        /// </summary>
+        public bool IsInitialized => _pool != null;
+
+        /// <summary>
+        /// Gets the count of currently inactive pooled objects.
+        /// </summary>
+        public int InactiveCount => _pool == null ? 0 : _pool.InactiveCount;
+
+        private void Awake()
+        {
+            EnsureInitialized();
+
+            if (prewarmOnAwake)
+            {
+                _pool.Prewarm(initialCapacity);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_pool != null)
+            {
+                _pool.Clear(destroyAll: true);
+            }
+        }
+
+        /// <summary>
+        /// Initializes the runtime pool if needed.
+        /// </summary>
+        public void EnsureInitialized()
+        {
+            if (_pool != null)
+            {
+                return;
+            }
+
+            if (prefab == null)
+            {
+                Debug.LogWarning($"{nameof(GameObjectPoolBehaviour)} on '{name}' cannot initialize without a prefab.", this);
+                return;
+            }
+
+            Transform poolParent = inactiveParent != null ? inactiveParent : transform;
+
+            _pool = new GameObjectPool(
+                prefab,
+                initialCapacity: 0,
+                maxCapacity,
+                poolParent,
+                activateOnSpawn,
+                deactivateOnDespawn);
+        }
+
+        /// <summary>
+        /// Spawns an instance from this pool.
+        /// </summary>
+        /// <param name="position">Optional world position.</param>
+        /// <param name="rotation">Optional world rotation.</param>
+        /// <param name="parent">Optional active parent transform.</param>
+        /// <returns>Spawned instance or null when pool is unavailable.</returns>
+        public GameObject Spawn(Vector3? position = null, Quaternion? rotation = null, Transform parent = null)
+        {
+            EnsureInitialized();
+            return _pool == null ? null : _pool.Spawn(position, rotation, parent);
+        }
+
+        /// <summary>
+        /// Returns an instance to this pool.
+        /// </summary>
+        /// <param name="instance">Instance to despawn.</param>
+        /// <returns>True when the instance was successfully returned.</returns>
+        public bool Despawn(GameObject instance)
+        {
+            if (_pool == null)
+            {
+                return false;
+            }
+
+            return _pool.Despawn(instance);
+        }
+
+        /// <summary>
+        /// Prewarms the pool with additional objects.
+        /// </summary>
+        /// <param name="count">Count to prewarm.</param>
+        public void Prewarm(int count)
+        {
+            EnsureInitialized();
+            _pool?.Prewarm(count);
+        }
+
+        /// <summary>
+        /// Clears pooled instances.
+        /// </summary>
+        /// <param name="destroyAll">When true, also destroys tracked active instances.</param>
+        public void Clear(bool destroyAll = false)
+        {
+            _pool?.Clear(destroyAll);
+        }
+    }
+}

--- a/Runtime/Pooling/ObjectPool.cs
+++ b/Runtime/Pooling/ObjectPool.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityUtilities.Pooling
+{
+    /// <summary>
+    /// Generic reusable object pool with configurable prewarm and maximum capacity.
+    /// </summary>
+    /// <typeparam name="T">Type of pooled object.</typeparam>
+    public sealed class ObjectPool<T> where T : class
+    {
+        private readonly Stack<T> _inactive;
+        private readonly HashSet<T> _inactiveLookup;
+        private readonly HashSet<T> _allInstances;
+
+        private readonly Func<T> _createFunc;
+        private readonly Action<T> _onGet;
+        private readonly Action<T> _onReturn;
+        private readonly Action<T> _onDestroy;
+        private readonly Func<T, bool> _isValid;
+
+        /// <summary>
+        /// Creates a new object pool.
+        /// </summary>
+        /// <param name="createFunc">Factory used to create new instances.</param>
+        /// <param name="onGet">Callback invoked when an object is retrieved from the pool.</param>
+        /// <param name="onReturn">Callback invoked when an object is returned to the pool.</param>
+        /// <param name="onDestroy">Callback invoked when an object is discarded/destroyed.</param>
+        /// <param name="isValid">Optional validation callback for inactive entries. Invalid entries are culled.</param>
+        /// <param name="initialCapacity">Number of objects to prewarm into the pool.</param>
+        /// <param name="maxCapacity">Maximum number of pooled inactive objects kept for reuse.</param>
+        public ObjectPool(
+            Func<T> createFunc,
+            Action<T> onGet = null,
+            Action<T> onReturn = null,
+            Action<T> onDestroy = null,
+            Func<T, bool> isValid = null,
+            int initialCapacity = 0,
+            int maxCapacity = int.MaxValue)
+        {
+            if (createFunc == null)
+            {
+                throw new ArgumentNullException(nameof(createFunc));
+            }
+
+            if (initialCapacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initialCapacity), "Initial capacity must be >= 0.");
+            }
+
+            if (maxCapacity < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxCapacity), "Max capacity must be >= 1.");
+            }
+
+            _createFunc = createFunc;
+            _onGet = onGet;
+            _onReturn = onReturn;
+            _onDestroy = onDestroy;
+            _isValid = isValid;
+
+            _inactive = new Stack<T>(Mathf.Max(initialCapacity, 1));
+            _inactiveLookup = new HashSet<T>();
+            _allInstances = new HashSet<T>();
+
+            MaxCapacity = maxCapacity;
+
+            Prewarm(initialCapacity);
+        }
+
+        /// <summary>
+        /// Gets the maximum number of inactive instances stored for reuse.
+        /// </summary>
+        public int MaxCapacity { get; }
+
+        /// <summary>
+        /// Gets the number of currently inactive pooled objects.
+        /// </summary>
+        public int InactiveCount => _inactive.Count;
+
+        /// <summary>
+        /// Gets the total number of known objects created by this pool.
+        /// </summary>
+        public int TotalCount => _allInstances.Count;
+
+        /// <summary>
+        /// Retrieves an instance from the pool, creating a new one when needed.
+        /// </summary>
+        /// <returns>A pooled instance.</returns>
+        public T Get()
+        {
+            T item;
+
+            while (_inactive.Count > 0)
+            {
+                item = _inactive.Pop();
+                _inactiveLookup.Remove(item);
+
+                if (IsValid(item))
+                {
+                    _onGet?.Invoke(item);
+                    return item;
+                }
+
+                _allInstances.Remove(item);
+            }
+
+            item = _createFunc();
+
+            if (!IsValid(item))
+            {
+                throw new InvalidOperationException("Pool create function returned an invalid instance.");
+            }
+
+            _allInstances.Add(item);
+            _onGet?.Invoke(item);
+            return item;
+        }
+
+        /// <summary>
+        /// Returns an instance to the pool.
+        /// </summary>
+        /// <param name="item">The instance to return.</param>
+        /// <returns>True if returned to pool; false when ignored/discarded.</returns>
+        public bool Return(T item)
+        {
+            if (!IsValid(item))
+            {
+                return false;
+            }
+
+            if (!_allInstances.Contains(item))
+            {
+                Debug.LogWarning($"Tried to return an item to pool {nameof(ObjectPool<T>)} that was not created by this pool: {item}.");
+                return false;
+            }
+
+            if (_inactiveLookup.Contains(item))
+            {
+                Debug.LogWarning($"Tried to return item to pool {nameof(ObjectPool<T>)} more than once: {item}.");
+                return false;
+            }
+
+            _onReturn?.Invoke(item);
+
+            if (_inactive.Count >= MaxCapacity)
+            {
+                _allInstances.Remove(item);
+                _onDestroy?.Invoke(item);
+                return false;
+            }
+
+            _inactive.Push(item);
+            _inactiveLookup.Add(item);
+            return true;
+        }
+
+        /// <summary>
+        /// Prewarms the pool by creating and returning new instances.
+        /// </summary>
+        /// <param name="count">Number of instances to create.</param>
+        public void Prewarm(int count)
+        {
+            if (count <= 0)
+            {
+                return;
+            }
+
+            int toCreate = Mathf.Min(count, MaxCapacity - _inactive.Count);
+            for (int i = 0; i < toCreate; i++)
+            {
+                T item = _createFunc();
+                if (!IsValid(item))
+                {
+                    continue;
+                }
+
+                _allInstances.Add(item);
+                _onReturn?.Invoke(item);
+                _inactive.Push(item);
+                _inactiveLookup.Add(item);
+            }
+        }
+
+        /// <summary>
+        /// Clears pooled inactive instances.
+        /// </summary>
+        /// <param name="destroyAll">When true, also destroys active tracked instances and fully resets pool state.</param>
+        public void Clear(bool destroyAll = false)
+        {
+            while (_inactive.Count > 0)
+            {
+                T item = _inactive.Pop();
+                _inactiveLookup.Remove(item);
+                _allInstances.Remove(item);
+
+                if (IsValid(item))
+                {
+                    _onDestroy?.Invoke(item);
+                }
+            }
+
+            if (!destroyAll)
+            {
+                return;
+            }
+
+            if (_allInstances.Count == 0)
+            {
+                return;
+            }
+
+            T[] remaining = new T[_allInstances.Count];
+            _allInstances.CopyTo(remaining);
+            for (int i = 0; i < remaining.Length; i++)
+            {
+                T item = remaining[i];
+                _allInstances.Remove(item);
+                _inactiveLookup.Remove(item);
+
+                if (IsValid(item))
+                {
+                    _onDestroy?.Invoke(item);
+                }
+            }
+        }
+
+        private bool IsValid(T item)
+        {
+            if (_isValid != null)
+            {
+                return _isValid(item);
+            }
+
+            return item != null;
+        }
+    }
+}

--- a/Samples/Pooling/PoolingExample.cs
+++ b/Samples/Pooling/PoolingExample.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+using UnityUtilities.Pooling;
+
+namespace UnityUtilities.Samples.Pooling
+{
+    /// <summary>
+    /// Minimal example showing spawn and timed despawn with <see cref="GameObjectPoolBehaviour"/>.
+    /// </summary>
+    public sealed class PoolingExample : MonoBehaviour
+    {
+        [SerializeField] private GameObjectPoolBehaviour pool;
+        [SerializeField] private float spawnIntervalSeconds = 0.5f;
+        [SerializeField] private float lifetimeSeconds = 2f;
+        [SerializeField] private Transform spawnPoint;
+
+        private float _elapsed;
+
+        private void Update()
+        {
+            if (pool == null)
+            {
+                return;
+            }
+
+            _elapsed += Time.deltaTime;
+            if (_elapsed < spawnIntervalSeconds)
+            {
+                return;
+            }
+
+            _elapsed = 0f;
+            Vector3 spawnPosition = spawnPoint != null ? spawnPoint.position : transform.position;
+            GameObject instance = pool.Spawn(spawnPosition, Quaternion.identity);
+            if (instance != null)
+            {
+                StartCoroutine(DespawnAfterDelay(instance));
+            }
+        }
+
+        private System.Collections.IEnumerator DespawnAfterDelay(GameObject instance)
+        {
+            yield return new WaitForSeconds(lifetimeSeconds);
+
+            if (instance != null)
+            {
+                pool.Despawn(instance);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, reusable object pooling framework suitable for general C# and Unity usage to reduce allocations and simplify spawn/despawn flows.
- Expose Unity-specific helpers for prefab-based pooling and typed component pooling so the system can be used in scenes and runtime code.
- Offer an inspector-driven component and a minimal sample to make it easy to evaluate and adopt the pool in projects.

### Description
- Added a generic core `ObjectPool<T>` with `Get`, `Return`, `Prewarm`, `Clear`, ownership tracking, invalid-entry culling, configurable `MaxCapacity`, and optional lifecycle callbacks; public APIs include XML documentation comments (`Runtime/Pooling/ObjectPool.cs`).
- Added `GameObjectPool` which wraps `ObjectPool<GameObject>` and supports prefab instantiation, optional inactive parent, optional activate-on-get and deactivate-on-return, and destroy-on-clear behavior (`Runtime/Pooling/GameObjectPool.cs`).
- Added `ComponentPool<TComponent>` on top of `GameObjectPool` for typed component pooling (`Runtime/Pooling/ComponentPool.cs`).
- Added `GameObjectPoolBehaviour`, an inspector-driven MonoBehaviour with serialized fields for `prefab`, capacities, inactive parent, activation toggles, and optional prewarm-on-awake so pools can be configured from the Unity Editor (`Runtime/Pooling/GameObjectPoolBehaviour.cs`).
- Added `PoolingExample` sample MonoBehaviour demonstrating periodic spawn and delayed despawn using the inspector-driven pool (`Samples/Pooling/PoolingExample.cs`).
- The implementation safely handles returning foreign objects and double-returns via warnings, tolerates destroyed/null entries, and keeps normal `Get`/`Return` paths allocation-free aside from Unity operations.

### Testing
- Ran repository state and file inspection checks to confirm the new files were created and contain the expected APIs, and those checks succeeded.
- Verified file contents with line-numbered previews to ensure public signatures and XML docs were present, and this inspection succeeded.
- Unity Editor compilation and playmode tests were not executed in this environment because the Unity Editor is not available; please run the Unity project compile/playmode tests locally or in CI to validate integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee26c2951c8320949f4177c0308e89)