### PR TITLE
Add minimal prototype-friendly IK module

### DIFF
--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d25ce934f192429498f8ae5c6c9226c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/IK.meta
+++ b/Editor/IK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24b9ff46ec6e48e6a3d9de6f31e560f2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/IK/FABRIKChainEditor.cs
+++ b/Editor/IK/FABRIKChainEditor.cs
@@ -1,0 +1,49 @@
+using jlinkdev.UnityUtilities.IK;
+using UnityEditor;
+
+namespace jlinkdev.UnityUtilities.Editor.IK
+{
+    [CustomEditor(typeof(FABRIKChain))]
+    public sealed class FABRIKChainEditor : UnityEditor.Editor
+    {
+        private SerializedProperty _joints;
+        private SerializedProperty _target;
+        private SerializedProperty _pole;
+        private SerializedProperty _iterations;
+        private SerializedProperty _tolerance;
+        private SerializedProperty _lockRoot;
+        private SerializedProperty _weight;
+        private SerializedProperty _solveInLateUpdate;
+        private SerializedProperty _drawGizmos;
+
+        private void OnEnable()
+        {
+            _joints = serializedObject.FindProperty("joints");
+            _target = serializedObject.FindProperty("target");
+            _pole = serializedObject.FindProperty("pole");
+            _iterations = serializedObject.FindProperty("iterations");
+            _tolerance = serializedObject.FindProperty("tolerance");
+            _lockRoot = serializedObject.FindProperty("lockRoot");
+            _weight = serializedObject.FindProperty("weight");
+            _solveInLateUpdate = serializedObject.FindProperty("solveInLateUpdate");
+            _drawGizmos = serializedObject.FindProperty("drawGizmos");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(_joints);
+            EditorGUILayout.PropertyField(_target);
+            EditorGUILayout.PropertyField(_pole);
+            EditorGUILayout.PropertyField(_iterations);
+            EditorGUILayout.PropertyField(_tolerance);
+            EditorGUILayout.PropertyField(_lockRoot);
+            EditorGUILayout.PropertyField(_weight);
+            EditorGUILayout.PropertyField(_solveInLateUpdate);
+            EditorGUILayout.PropertyField(_drawGizmos);
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Editor/IK/FABRIKChainEditor.cs.meta
+++ b/Editor/IK/FABRIKChainEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e14f1e855f7d46ddbd2ec12e709c4f14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/jlinkdev.UnityUtilities.Editor.asmdef
+++ b/Editor/jlinkdev.UnityUtilities.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+  "name": "jlinkdev.UnityUtilities.Editor",
+  "rootNamespace": "jlinkdev.UnityUtilities.Editor",
+  "references": [
+    "jlinkdev.UnityUtilities"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Editor/jlinkdev.UnityUtilities.Editor.asmdef.meta
+++ b/Editor/jlinkdev.UnityUtilities.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 75ac6069f3ef47d883ca0c94adfe35d8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,30 @@ Use the pooling APIs at the level that matches the project need:
 - `GameObjectPoolRegistry`: inspector-friendly scene component for multiple prefab pools looked up by prefab reference.
 
 `GameObjectPoolRegistry` is intended as the scalable default when a project has many pooled prefabs. It owns a serialized list of `GameObjectPoolDefinition` entries, initializes one `GameObjectPool` per prefab, tracks which pool spawned each active instance, and supports despawning by instance.
+
+## IK module (`Runtime/IK`)
+A tiny, prototype-friendly set of IK components under `jlinkdev.UnityUtilities.IK` for common procedural rig problems.
+
+### What it is for
+- Quick limb, chain, and aiming behaviors
+- Procedural gameplay and rapid iteration
+- Drop-in scene components with minimal setup
+
+### What it is NOT for
+- Full-body or VR IK
+- Animator/animation-graph integration frameworks
+- Heavy constraint systems or advanced editor tooling
+
+### Quick setup
+- **TwoBoneIK**: add to any GameObject, assign `root`, `mid`, `tip`, `target` (optional `pole`), then play.
+- **FABRIKChain**: add component, assign `joints` root-to-tip and `target`, tweak iterations/tolerance if needed.
+- **AimIK**: assign a joint chain and target, set `localAimAxis` to match the rig's forward axis.
+- **GroundProbe**: assign `rayOrigin`, set cast distance/layers, then use this transform as an IK target.
+
+### Update timing
+- Solvers run in `LateUpdate` by default and can also be called manually via `Solve()`.
+
+### Known limitations
+- These are intentionally lightweight solvers and do not cover advanced animation workflows.
+- Pole behavior in FABRIK is a simple bias and may need scene-specific tuning.
+- RotationLimit is intentionally basic (single hinge or cone clamp only).

--- a/Runtime/IK.meta
+++ b/Runtime/IK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 376e3237276c7634ab0898481ed099ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/IK/AimIK.cs
+++ b/Runtime/IK/AimIK.cs
@@ -19,6 +19,48 @@ namespace jlinkdev.UnityUtilities.IK
         [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
         private bool drawGizmos = true;
 
+        public Transform[] Joints
+        {
+            get => joints;
+            set => joints = value;
+        }
+
+        public Transform Target
+        {
+            get => target;
+            set => target = value;
+        }
+
+        public Vector3 LocalAimAxis
+        {
+            get => localAimAxis;
+            set => localAimAxis = value.sqrMagnitude > 0.00001f ? value.normalized : Vector3.forward;
+        }
+
+        public int Iterations
+        {
+            get => iterations;
+            set => iterations = Mathf.Max(1, value);
+        }
+
+        public float Weight
+        {
+            get => weight;
+            set => weight = IKMath.ClampWeight(value);
+        }
+
+        public bool SolveInLateUpdate
+        {
+            get => solveInLateUpdate;
+            set => solveInLateUpdate = value;
+        }
+
+        public bool DrawGizmos
+        {
+            get => drawGizmos;
+            set => drawGizmos = value;
+        }
+
         public void Solve()
         {
             if (joints == null || joints.Length == 0 || target == null) return;
@@ -41,22 +83,38 @@ namespace jlinkdev.UnityUtilities.IK
 
         private void LateUpdate() { if (solveInLateUpdate) Solve(); }
 
+        private void OnDrawGizmos()
+        {
+            DrawDebugGizmos(0.25f);
+        }
+
         private void OnDrawGizmosSelected()
         {
+            DrawDebugGizmos(1f);
+        }
+
+        private void DrawDebugGizmos(float alphaScale)
+        {
             if (!drawGizmos || joints == null || joints.Length == 0) return;
-            Gizmos.color = Color.cyan;
+            Gizmos.color = WithAlpha(Color.cyan, 1f * alphaScale);
             for (int i = 0; i < joints.Length - 1; i++) if (joints[i] != null && joints[i + 1] != null) Gizmos.DrawLine(joints[i].position, joints[i + 1].position);
             Transform tip = joints[joints.Length - 1];
             if (tip != null)
             {
-                Gizmos.color = Color.yellow;
+                Gizmos.color = WithAlpha(Color.yellow, 1f * alphaScale);
                 Gizmos.DrawRay(tip.position, tip.TransformDirection(localAimAxis.normalized) * 0.5f);
             }
             if (target != null && tip != null)
             {
-                Gizmos.color = Color.green;
+                Gizmos.color = WithAlpha(Color.green, 1f * alphaScale);
                 Gizmos.DrawLine(tip.position, target.position);
             }
+        }
+
+        private static Color WithAlpha(Color color, float alpha)
+        {
+            color.a = Mathf.Clamp01(alpha);
+            return color;
         }
     }
 }

--- a/Runtime/IK/AimIK.cs
+++ b/Runtime/IK/AimIK.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    public sealed class AimIK : MonoBehaviour
+    {
+        [SerializeField, Tooltip("Transforms to rotate from root to tip in order.")]
+        private Transform[] joints;
+        [SerializeField, Tooltip("Transform to aim at.")]
+        private Transform target;
+        [SerializeField, Tooltip("Local axis that should point at the target.")]
+        private Vector3 localAimAxis = Vector3.forward;
+        [SerializeField, Tooltip("CCD-style iteration count.")]
+        private int iterations = 5;
+        [SerializeField, Tooltip("Blend from 0 (disabled) to 1 (full IK).")]
+        private float weight = 1f;
+        [SerializeField, Tooltip("Run solver every LateUpdate automatically.")]
+        private bool solveInLateUpdate = true;
+        [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
+        private bool drawGizmos = true;
+
+        public void Solve()
+        {
+            if (joints == null || joints.Length == 0 || target == null) return;
+            float solveWeight = IKMath.ClampWeight(weight);
+            if (solveWeight <= 0f) return;
+
+            Transform tip = joints[joints.Length - 1];
+            for (int step = 0; step < iterations; step++)
+            {
+                for (int i = joints.Length - 1; i >= 0; i--)
+                {
+                    Vector3 currentAim = joints[i].TransformDirection(localAimAxis.normalized);
+                    Vector3 toTarget = (target.position - tip.position).normalized;
+                    if (toTarget.sqrMagnitude <= 0.00001f || currentAim.sqrMagnitude <= 0.00001f) continue;
+                    Quaternion delta = Quaternion.FromToRotation(currentAim, toTarget);
+                    joints[i].rotation = Quaternion.Slerp(joints[i].rotation, delta * joints[i].rotation, solveWeight);
+                }
+            }
+        }
+
+        private void LateUpdate() { if (solveInLateUpdate) Solve(); }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!drawGizmos || joints == null || joints.Length == 0) return;
+            Gizmos.color = Color.cyan;
+            for (int i = 0; i < joints.Length - 1; i++) if (joints[i] != null && joints[i + 1] != null) Gizmos.DrawLine(joints[i].position, joints[i + 1].position);
+            Transform tip = joints[joints.Length - 1];
+            if (tip != null)
+            {
+                Gizmos.color = Color.yellow;
+                Gizmos.DrawRay(tip.position, tip.TransformDirection(localAimAxis.normalized) * 0.5f);
+            }
+            if (target != null && tip != null)
+            {
+                Gizmos.color = Color.green;
+                Gizmos.DrawLine(tip.position, target.position);
+            }
+        }
+    }
+}

--- a/Runtime/IK/AimIK.cs.meta
+++ b/Runtime/IK/AimIK.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18f8cd95de6fc9047a2597effdfcd97c

--- a/Runtime/IK/FABRIKChain.cs
+++ b/Runtime/IK/FABRIKChain.cs
@@ -31,6 +31,60 @@ namespace jlinkdev.UnityUtilities.IK
         [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
         private bool drawGizmos = true;
 
+        public Transform[] Joints
+        {
+            get => joints;
+            set => joints = value;
+        }
+
+        public Transform Target
+        {
+            get => target;
+            set => target = value;
+        }
+
+        public Transform Pole
+        {
+            get => pole;
+            set => pole = value;
+        }
+
+        public int Iterations
+        {
+            get => iterations;
+            set => iterations = Mathf.Max(1, value);
+        }
+
+        public float Tolerance
+        {
+            get => tolerance;
+            set => tolerance = Mathf.Max(0f, value);
+        }
+
+        public bool LockRoot
+        {
+            get => lockRoot;
+            set => lockRoot = value;
+        }
+
+        public float Weight
+        {
+            get => weight;
+            set => weight = IKMath.ClampWeight(value);
+        }
+
+        public bool SolveInLateUpdate
+        {
+            get => solveInLateUpdate;
+            set => solveInLateUpdate = value;
+        }
+
+        public bool DrawGizmos
+        {
+            get => drawGizmos;
+            set => drawGizmos = value;
+        }
+
         public void Solve()
         {
             if (joints == null || joints.Length < 2 || target == null) return;
@@ -99,14 +153,24 @@ namespace jlinkdev.UnityUtilities.IK
 
         private void LateUpdate() { if (solveInLateUpdate) Solve(); }
 
+        private void OnDrawGizmos()
+        {
+            DrawDebugGizmos(0.25f);
+        }
+
         private void OnDrawGizmosSelected()
         {
+            DrawDebugGizmos(1f);
+        }
+
+        private void DrawDebugGizmos(float alphaScale)
+        {
             if (!drawGizmos || joints == null || joints.Length < 2) return;
-            Gizmos.color = Color.cyan;
+            Gizmos.color = WithAlpha(Color.cyan, 1f * alphaScale);
             for (int i = 0; i < joints.Length - 1; i++) if (joints[i] != null && joints[i + 1] != null) Gizmos.DrawLine(joints[i].position, joints[i + 1].position);
-            if (target != null)
+            if (target != null && joints[joints.Length - 1] != null)
             {
-                Gizmos.color = Color.green;
+                Gizmos.color = WithAlpha(Color.green, 1f * alphaScale);
                 Gizmos.DrawLine(joints[joints.Length - 1].position, target.position);
                 Gizmos.DrawWireSphere(target.position, 0.04f);
             }
@@ -114,16 +178,22 @@ namespace jlinkdev.UnityUtilities.IK
             if (joints[0] != null)
             {
                 Vector3[] p = new Vector3[joints.Length];
-                for (int i = 0; i < joints.Length; i++) p[i] = joints[i].position;
-                Gizmos.color = new Color(1f, 1f, 0f, 0.6f);
+                for (int i = 0; i < joints.Length; i++) p[i] = joints[i] != null ? joints[i].position : joints[0].position;
+                Gizmos.color = WithAlpha(Color.yellow, 0.6f * alphaScale);
                 Gizmos.DrawWireSphere(joints[0].position, IKMath.SumLengths(p));
             }
 
             if (pole != null)
             {
-                Gizmos.color = Color.magenta;
+                Gizmos.color = WithAlpha(Color.magenta, 1f * alphaScale);
                 Gizmos.DrawWireSphere(pole.position, 0.03f);
             }
+        }
+
+        private static Color WithAlpha(Color color, float alpha)
+        {
+            color.a = Mathf.Clamp01(alpha);
+            return color;
         }
     }
 }

--- a/Runtime/IK/FABRIKChain.cs
+++ b/Runtime/IK/FABRIKChain.cs
@@ -1,0 +1,129 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    public sealed class FABRIKChain : MonoBehaviour
+    {
+        [SerializeField, Tooltip("Joint chain from root to tip in order.")]
+        private Transform[] joints;
+
+        [SerializeField, Tooltip("Transform the chain tip should reach.")]
+        private Transform target;
+
+        [SerializeField, Tooltip("Optional pole transform to bias bend direction.")]
+        private Transform pole;
+
+        [SerializeField, Tooltip("Number of solver iterations per update.")]
+        private int iterations = 8;
+
+        [SerializeField, Tooltip("Stop early when tip is within this distance to target.")]
+        private float tolerance = 0.01f;
+
+        [SerializeField, Tooltip("Keep the root joint fixed in world space.")]
+        private bool lockRoot = true;
+
+        [SerializeField, Tooltip("Blend from 0 (disabled) to 1 (full IK).")]
+        private float weight = 1f;
+
+        [SerializeField, Tooltip("Run solver every LateUpdate automatically.")]
+        private bool solveInLateUpdate = true;
+
+        [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
+        private bool drawGizmos = true;
+
+        public void Solve()
+        {
+            if (joints == null || joints.Length < 2 || target == null) return;
+
+            float solveWeight = IKMath.ClampWeight(weight);
+            if (solveWeight <= 0f) return;
+
+            int count = joints.Length;
+            Vector3[] points = new Vector3[count];
+            float[] lengths = new float[count - 1];
+            for (int i = 0; i < count; i++) points[i] = joints[i].position;
+            for (int i = 0; i < count - 1; i++) lengths[i] = Vector3.Distance(points[i], points[i + 1]);
+
+            Vector3 rootStart = points[0];
+            float totalLen = 0f;
+            for (int i = 0; i < lengths.Length; i++) totalLen += lengths[i];
+            Vector3 targetPos = target.position;
+
+            if (Vector3.Distance(rootStart, targetPos) > totalLen)
+            {
+                Vector3 dir = (targetPos - rootStart).normalized;
+                for (int i = 1; i < count; i++) points[i] = points[i - 1] + (dir * lengths[i - 1]);
+            }
+            else
+            {
+                for (int iteration = 0; iteration < iterations; iteration++)
+                {
+                    points[count - 1] = targetPos;
+                    for (int i = count - 2; i >= 0; i--)
+                    {
+                        Vector3 dir = (points[i] - points[i + 1]).normalized;
+                        points[i] = points[i + 1] + (dir * lengths[i]);
+                    }
+
+                    if (lockRoot) points[0] = rootStart;
+                    for (int i = 1; i < count; i++)
+                    {
+                        Vector3 dir = (points[i] - points[i - 1]).normalized;
+                        points[i] = points[i - 1] + (dir * lengths[i - 1]);
+                    }
+
+                    if ((points[count - 1] - targetPos).sqrMagnitude < tolerance * tolerance) break;
+                }
+            }
+
+            if (pole != null)
+            {
+                for (int i = 1; i < count - 1; i++)
+                {
+                    Plane plane = new Plane(points[i + 1] - points[i - 1], points[i - 1]);
+                    Vector3 projectedPole = plane.ClosestPointOnPlane(pole.position);
+                    Vector3 projectedJoint = plane.ClosestPointOnPlane(points[i]);
+                    Vector3 fromJoint = projectedJoint - points[i - 1];
+                    Vector3 fromPole = projectedPole - points[i - 1];
+                    float angle = Vector3.SignedAngle(fromJoint, fromPole, plane.normal);
+                    points[i] = Quaternion.AngleAxis(angle, plane.normal) * (points[i] - points[i - 1]) + points[i - 1];
+                }
+            }
+
+            for (int i = 0; i < count - 1; i++)
+            {
+                Quaternion solved = Quaternion.FromToRotation(joints[i + 1].position - joints[i].position, points[i + 1] - points[i]) * joints[i].rotation;
+                joints[i].rotation = Quaternion.Slerp(joints[i].rotation, solved, solveWeight);
+            }
+        }
+
+        private void LateUpdate() { if (solveInLateUpdate) Solve(); }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!drawGizmos || joints == null || joints.Length < 2) return;
+            Gizmos.color = Color.cyan;
+            for (int i = 0; i < joints.Length - 1; i++) if (joints[i] != null && joints[i + 1] != null) Gizmos.DrawLine(joints[i].position, joints[i + 1].position);
+            if (target != null)
+            {
+                Gizmos.color = Color.green;
+                Gizmos.DrawLine(joints[joints.Length - 1].position, target.position);
+                Gizmos.DrawWireSphere(target.position, 0.04f);
+            }
+
+            if (joints[0] != null)
+            {
+                Vector3[] p = new Vector3[joints.Length];
+                for (int i = 0; i < joints.Length; i++) p[i] = joints[i].position;
+                Gizmos.color = new Color(1f, 1f, 0f, 0.6f);
+                Gizmos.DrawWireSphere(joints[0].position, IKMath.SumLengths(p));
+            }
+
+            if (pole != null)
+            {
+                Gizmos.color = Color.magenta;
+                Gizmos.DrawWireSphere(pole.position, 0.03f);
+            }
+        }
+    }
+}

--- a/Runtime/IK/FABRIKChain.cs.meta
+++ b/Runtime/IK/FABRIKChain.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b07886393d02cf46ae723d0e10da1cd

--- a/Runtime/IK/GroundProbe.cs
+++ b/Runtime/IK/GroundProbe.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    public sealed class GroundProbe : MonoBehaviour
+    {
+        [SerializeField, Tooltip("Origin transform used to cast toward the ground.")]
+        private Transform rayOrigin;
+        [SerializeField, Tooltip("Maximum cast distance.")]
+        private float rayDistance = 2f;
+        [SerializeField, Tooltip("Layer mask used for ground hits.")]
+        private LayerMask groundMask = ~0;
+        [SerializeField, Tooltip("World-space offset applied from hit point along normal.")]
+        private float surfaceOffset = 0.05f;
+        [SerializeField, Tooltip("Align this transform to the hit surface normal.")]
+        private bool alignToNormal = true;
+        [SerializeField, Tooltip("Position smoothing speed (0 = no smoothing).")]
+        private float positionSmooth = 15f;
+        [SerializeField, Tooltip("Rotation smoothing speed (0 = no smoothing).")]
+        private float rotationSmooth = 15f;
+        [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
+        private bool drawGizmos = true;
+
+        private bool _hasHit;
+        private RaycastHit _hit;
+
+        private void LateUpdate()
+        {
+            if (rayOrigin == null) return;
+            if (Physics.Raycast(rayOrigin.position, Vector3.down, out _hit, rayDistance, groundMask, QueryTriggerInteraction.Ignore))
+            {
+                _hasHit = true;
+                Vector3 targetPos = _hit.point + (_hit.normal * surfaceOffset);
+                if (positionSmooth > 0f)
+                {
+                    transform.position = Vector3.Lerp(transform.position, targetPos, Time.deltaTime * positionSmooth);
+                }
+                else
+                {
+                    transform.position = targetPos;
+                }
+
+                if (alignToNormal)
+                {
+                    Quaternion targetRot = IKMath.SafeLookRotation(Vector3.ProjectOnPlane(rayOrigin.forward, _hit.normal), _hit.normal);
+                    if (rotationSmooth > 0f) transform.rotation = Quaternion.Slerp(transform.rotation, targetRot, Time.deltaTime * rotationSmooth);
+                    else transform.rotation = targetRot;
+                }
+            }
+            else
+            {
+                _hasHit = false;
+            }
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!drawGizmos || rayOrigin == null) return;
+            Gizmos.color = Color.white;
+            Gizmos.DrawLine(rayOrigin.position, rayOrigin.position + Vector3.down * rayDistance);
+            if (_hasHit)
+            {
+                Gizmos.color = Color.green;
+                Gizmos.DrawWireSphere(_hit.point, 0.03f);
+                Gizmos.DrawRay(_hit.point, _hit.normal * 0.3f);
+            }
+        }
+    }
+}

--- a/Runtime/IK/GroundProbe.cs
+++ b/Runtime/IK/GroundProbe.cs
@@ -24,6 +24,57 @@ namespace jlinkdev.UnityUtilities.IK
         private bool _hasHit;
         private RaycastHit _hit;
 
+        public Transform RayOrigin
+        {
+            get => rayOrigin;
+            set => rayOrigin = value;
+        }
+
+        public float RayDistance
+        {
+            get => rayDistance;
+            set => rayDistance = Mathf.Max(0f, value);
+        }
+
+        public LayerMask GroundMask
+        {
+            get => groundMask;
+            set => groundMask = value;
+        }
+
+        public float SurfaceOffset
+        {
+            get => surfaceOffset;
+            set => surfaceOffset = value;
+        }
+
+        public bool AlignToNormal
+        {
+            get => alignToNormal;
+            set => alignToNormal = value;
+        }
+
+        public float PositionSmooth
+        {
+            get => positionSmooth;
+            set => positionSmooth = Mathf.Max(0f, value);
+        }
+
+        public float RotationSmooth
+        {
+            get => rotationSmooth;
+            set => rotationSmooth = Mathf.Max(0f, value);
+        }
+
+        public bool DrawGizmos
+        {
+            get => drawGizmos;
+            set => drawGizmos = value;
+        }
+
+        public bool HasHit => _hasHit;
+        public RaycastHit CurrentHit => _hit;
+
         private void LateUpdate()
         {
             if (rayOrigin == null) return;
@@ -53,17 +104,33 @@ namespace jlinkdev.UnityUtilities.IK
             }
         }
 
+        private void OnDrawGizmos()
+        {
+            DrawDebugGizmos(0.25f);
+        }
+
         private void OnDrawGizmosSelected()
         {
+            DrawDebugGizmos(1f);
+        }
+
+        private void DrawDebugGizmos(float alphaScale)
+        {
             if (!drawGizmos || rayOrigin == null) return;
-            Gizmos.color = Color.white;
+            Gizmos.color = WithAlpha(Color.white, 1f * alphaScale);
             Gizmos.DrawLine(rayOrigin.position, rayOrigin.position + Vector3.down * rayDistance);
             if (_hasHit)
             {
-                Gizmos.color = Color.green;
+                Gizmos.color = WithAlpha(Color.green, 1f * alphaScale);
                 Gizmos.DrawWireSphere(_hit.point, 0.03f);
                 Gizmos.DrawRay(_hit.point, _hit.normal * 0.3f);
             }
+        }
+
+        private static Color WithAlpha(Color color, float alpha)
+        {
+            color.a = Mathf.Clamp01(alpha);
+            return color;
         }
     }
 }

--- a/Runtime/IK/GroundProbe.cs.meta
+++ b/Runtime/IK/GroundProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90287af16431c9444a3f057ff3500cf0

--- a/Runtime/IK/IKMath.cs
+++ b/Runtime/IK/IKMath.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    internal static class IKMath
+    {
+        public static float ClampWeight(float value)
+        {
+            return Mathf.Clamp01(value);
+        }
+
+        public static Vector3 ProjectOntoPlane(Vector3 vector, Vector3 planeNormal)
+        {
+            return vector - Vector3.Project(vector, planeNormal);
+        }
+
+        public static Quaternion SafeLookRotation(Vector3 forward, Vector3 up)
+        {
+            if (forward.sqrMagnitude <= 0.000001f)
+            {
+                return Quaternion.identity;
+            }
+
+            Vector3 safeUp = up.sqrMagnitude > 0.000001f ? up : Vector3.up;
+            return Quaternion.LookRotation(forward.normalized, safeUp.normalized);
+        }
+
+        public static float SumLengths(Vector3[] points)
+        {
+            float total = 0f;
+            for (int i = 0; i < points.Length - 1; i++)
+            {
+                total += Vector3.Distance(points[i], points[i + 1]);
+            }
+
+            return total;
+        }
+    }
+}

--- a/Runtime/IK/IKMath.cs.meta
+++ b/Runtime/IK/IKMath.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6fc368dcea9e384429af0b68878d2460

--- a/Runtime/IK/IKTarget.cs
+++ b/Runtime/IK/IKTarget.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    public sealed class IKTarget : MonoBehaviour
+    {
+        [SerializeField, Tooltip("Draw gizmo in scene view for this target marker.")]
+        private bool drawGizmo = true;
+
+        private void OnDrawGizmos()
+        {
+            if (!drawGizmo) return;
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireSphere(transform.position, 0.05f);
+        }
+    }
+}

--- a/Runtime/IK/IKTarget.cs.meta
+++ b/Runtime/IK/IKTarget.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c7cbcca2c85b6c5458074719c4fad46b

--- a/Runtime/IK/PoleHint.cs
+++ b/Runtime/IK/PoleHint.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    public sealed class PoleHint : MonoBehaviour
+    {
+        [SerializeField, Tooltip("Draw gizmo in scene view for this pole hint marker.")]
+        private bool drawGizmo = true;
+
+        private void OnDrawGizmos()
+        {
+            if (!drawGizmo) return;
+            Gizmos.color = Color.magenta;
+            Gizmos.DrawWireCube(transform.position, Vector3.one * 0.06f);
+        }
+    }
+}

--- a/Runtime/IK/PoleHint.cs.meta
+++ b/Runtime/IK/PoleHint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36c8756fa6197f7428c0416a06df11da

--- a/Runtime/IK/RotationLimit.cs
+++ b/Runtime/IK/RotationLimit.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    public sealed class RotationLimit : MonoBehaviour
+    {
+        public enum LimitMode { Hinge, Cone }
+
+        [SerializeField, Tooltip("Limit mode: simple hinge or simple cone.")]
+        private LimitMode mode = LimitMode.Cone;
+        [SerializeField, Tooltip("Local axis used by the limit.")]
+        private Vector3 localAxis = Vector3.forward;
+        [SerializeField, Tooltip("Minimum hinge angle in degrees.")]
+        private float hingeMin = -45f;
+        [SerializeField, Tooltip("Maximum hinge angle in degrees.")]
+        private float hingeMax = 45f;
+        [SerializeField, Tooltip("Cone half-angle in degrees.")]
+        private float coneAngle = 45f;
+        [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
+        private bool drawGizmos = true;
+
+        private Quaternion _initialLocalRotation;
+
+        private void Awake() { _initialLocalRotation = transform.localRotation; }
+
+        public void ApplyLimit()
+        {
+            Vector3 axis = localAxis.normalized;
+            if (axis.sqrMagnitude <= 0.00001f) return;
+
+            Quaternion relative = Quaternion.Inverse(_initialLocalRotation) * transform.localRotation;
+            if (mode == LimitMode.Hinge)
+            {
+                relative.ToAngleAxis(out float angle, out Vector3 outAxis);
+                angle = Mathf.DeltaAngle(0f, angle * Mathf.Sign(Vector3.Dot(outAxis, axis)));
+                angle = Mathf.Clamp(angle, hingeMin, hingeMax);
+                transform.localRotation = _initialLocalRotation * Quaternion.AngleAxis(angle, axis);
+            }
+            else
+            {
+                Vector3 dir = relative * axis;
+                float angle = Vector3.Angle(axis, dir);
+                if (angle > coneAngle)
+                {
+                    Vector3 cross = Vector3.Cross(axis, dir);
+                    if (cross.sqrMagnitude > 0.00001f)
+                    {
+                        Quaternion clamp = Quaternion.AngleAxis(coneAngle, cross.normalized) * Quaternion.FromToRotation(cross, cross);
+                        transform.localRotation = _initialLocalRotation * clamp;
+                    }
+                }
+            }
+        }
+
+        private void LateUpdate() { ApplyLimit(); }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!drawGizmos) return;
+            Vector3 worldAxis = transform.TransformDirection(localAxis.normalized);
+            if (mode == LimitMode.Hinge)
+            {
+                Gizmos.color = Color.yellow;
+                Gizmos.DrawRay(transform.position, Quaternion.AngleAxis(hingeMin, worldAxis) * transform.up * 0.5f);
+                Gizmos.DrawRay(transform.position, Quaternion.AngleAxis(hingeMax, worldAxis) * transform.up * 0.5f);
+            }
+            else
+            {
+                Gizmos.color = new Color(1f, 0.5f, 0f, 0.8f);
+                Gizmos.DrawRay(transform.position, worldAxis * 0.5f);
+                Gizmos.DrawWireSphere(transform.position + worldAxis * 0.5f, Mathf.Sin(coneAngle * Mathf.Deg2Rad) * 0.5f);
+            }
+        }
+    }
+}

--- a/Runtime/IK/RotationLimit.cs
+++ b/Runtime/IK/RotationLimit.cs
@@ -54,22 +54,38 @@ namespace jlinkdev.UnityUtilities.IK
 
         private void LateUpdate() { ApplyLimit(); }
 
+        private void OnDrawGizmos()
+        {
+            DrawDebugGizmos(0.25f);
+        }
+
         private void OnDrawGizmosSelected()
+        {
+            DrawDebugGizmos(1f);
+        }
+
+        private void DrawDebugGizmos(float alphaScale)
         {
             if (!drawGizmos) return;
             Vector3 worldAxis = transform.TransformDirection(localAxis.normalized);
             if (mode == LimitMode.Hinge)
             {
-                Gizmos.color = Color.yellow;
+                Gizmos.color = WithAlpha(Color.yellow, 1f * alphaScale);
                 Gizmos.DrawRay(transform.position, Quaternion.AngleAxis(hingeMin, worldAxis) * transform.up * 0.5f);
                 Gizmos.DrawRay(transform.position, Quaternion.AngleAxis(hingeMax, worldAxis) * transform.up * 0.5f);
             }
             else
             {
-                Gizmos.color = new Color(1f, 0.5f, 0f, 0.8f);
+                Gizmos.color = new Color(1f, 0.5f, 0f, 0.8f * alphaScale);
                 Gizmos.DrawRay(transform.position, worldAxis * 0.5f);
                 Gizmos.DrawWireSphere(transform.position + worldAxis * 0.5f, Mathf.Sin(coneAngle * Mathf.Deg2Rad) * 0.5f);
             }
+        }
+
+        private static Color WithAlpha(Color color, float alpha)
+        {
+            color.a = Mathf.Clamp01(alpha);
+            return color;
         }
     }
 }

--- a/Runtime/IK/RotationLimit.cs.meta
+++ b/Runtime/IK/RotationLimit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d419ca46d2094bf4b898be3ea65ec3b5

--- a/Runtime/IK/TwoBoneIK.cs
+++ b/Runtime/IK/TwoBoneIK.cs
@@ -1,0 +1,132 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.IK
+{
+    public sealed class TwoBoneIK : MonoBehaviour
+    {
+        [SerializeField, Tooltip("Upper joint of the limb (for example shoulder or hip).")]
+        private Transform root;
+
+        [SerializeField, Tooltip("Middle joint of the limb (for example elbow or knee).")]
+        private Transform mid;
+
+        [SerializeField, Tooltip("End joint of the limb (for example wrist or ankle).")]
+        private Transform tip;
+
+        [SerializeField, Tooltip("Transform the tip should move toward.")]
+        private Transform target;
+
+        [SerializeField, Tooltip("Optional pole transform that controls bend direction.")]
+        private Transform pole;
+
+        [SerializeField, Tooltip("Blend from 0 (disabled) to 1 (full IK).")]
+        private float weight = 1f;
+
+        [SerializeField, Tooltip("When enabled, tip rotation will match target rotation.")]
+        private bool matchTipRotation = true;
+
+        [SerializeField, Tooltip("Run solver every LateUpdate automatically.")]
+        private bool solveInLateUpdate = true;
+
+        [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
+        private bool drawGizmos = true;
+
+        public void Solve()
+        {
+            if (root == null || mid == null || tip == null || target == null)
+            {
+                return;
+            }
+
+            float solveWeight = IKMath.ClampWeight(weight);
+            if (solveWeight <= 0f)
+            {
+                return;
+            }
+
+            Vector3 rootPos = root.position;
+            Vector3 midPos = mid.position;
+            Vector3 tipPos = tip.position;
+
+            float upperLen = Vector3.Distance(rootPos, midPos);
+            float lowerLen = Vector3.Distance(midPos, tipPos);
+            Vector3 toTarget = target.position - rootPos;
+            float targetDist = Mathf.Max(0.0001f, toTarget.magnitude);
+            float maxReach = upperLen + lowerLen;
+            float clampedDist = Mathf.Min(targetDist, maxReach - 0.0001f);
+
+            Vector3 dirToTarget = toTarget.normalized;
+            Vector3 bendNormal = Vector3.Cross(midPos - rootPos, tipPos - midPos).normalized;
+            if (bendNormal.sqrMagnitude < 0.0001f)
+            {
+                bendNormal = Vector3.up;
+            }
+
+            if (pole != null)
+            {
+                Vector3 poleDir = IKMath.ProjectOntoPlane(pole.position - rootPos, dirToTarget).normalized;
+                if (poleDir.sqrMagnitude > 0.0001f)
+                {
+                    bendNormal = Vector3.Cross(dirToTarget, poleDir).normalized;
+                }
+            }
+
+            float cosAngle = ((upperLen * upperLen) + (clampedDist * clampedDist) - (lowerLen * lowerLen)) / (2f * upperLen * clampedDist);
+            float angle = Mathf.Acos(Mathf.Clamp(cosAngle, -1f, 1f));
+
+            Vector3 bendDir = Quaternion.AngleAxis(-Mathf.Rad2Deg * angle, bendNormal) * dirToTarget;
+            Vector3 solvedMidPos = rootPos + (bendDir * upperLen);
+
+            Quaternion rootRotation = Quaternion.FromToRotation(midPos - rootPos, solvedMidPos - rootPos) * root.rotation;
+            root.rotation = Quaternion.Slerp(root.rotation, rootRotation, solveWeight);
+
+            midPos = mid.position;
+            tipPos = tip.position;
+            Quaternion midRotation = Quaternion.FromToRotation(tipPos - midPos, target.position - midPos) * mid.rotation;
+            mid.rotation = Quaternion.Slerp(mid.rotation, midRotation, solveWeight);
+
+            if (matchTipRotation)
+            {
+                tip.rotation = Quaternion.Slerp(tip.rotation, target.rotation, solveWeight);
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (solveInLateUpdate)
+            {
+                Solve();
+            }
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            if (!drawGizmos || root == null || mid == null || tip == null)
+            {
+                return;
+            }
+
+            Gizmos.color = Color.cyan;
+            Gizmos.DrawLine(root.position, mid.position);
+            Gizmos.DrawLine(mid.position, tip.position);
+
+            float reach = Vector3.Distance(root.position, mid.position) + Vector3.Distance(mid.position, tip.position);
+            Gizmos.color = new Color(1f, 1f, 0f, 0.6f);
+            Gizmos.DrawWireSphere(root.position, reach);
+
+            if (target != null)
+            {
+                Gizmos.color = Color.green;
+                Gizmos.DrawLine(tip.position, target.position);
+                Gizmos.DrawWireSphere(target.position, 0.04f);
+            }
+
+            if (pole != null)
+            {
+                Gizmos.color = Color.magenta;
+                Gizmos.DrawLine(root.position, pole.position);
+                Gizmos.DrawWireSphere(pole.position, 0.03f);
+            }
+        }
+    }
+}

--- a/Runtime/IK/TwoBoneIK.cs
+++ b/Runtime/IK/TwoBoneIK.cs
@@ -31,6 +31,60 @@ namespace jlinkdev.UnityUtilities.IK
         [SerializeField, Tooltip("Draw gizmo debug visuals in the scene view.")]
         private bool drawGizmos = true;
 
+        public Transform Root
+        {
+            get => root;
+            set => root = value;
+        }
+
+        public Transform Mid
+        {
+            get => mid;
+            set => mid = value;
+        }
+
+        public Transform Tip
+        {
+            get => tip;
+            set => tip = value;
+        }
+
+        public Transform Target
+        {
+            get => target;
+            set => target = value;
+        }
+
+        public Transform Pole
+        {
+            get => pole;
+            set => pole = value;
+        }
+
+        public float Weight
+        {
+            get => weight;
+            set => weight = IKMath.ClampWeight(value);
+        }
+
+        public bool MatchTipRotation
+        {
+            get => matchTipRotation;
+            set => matchTipRotation = value;
+        }
+
+        public bool SolveInLateUpdate
+        {
+            get => solveInLateUpdate;
+            set => solveInLateUpdate = value;
+        }
+
+        public bool DrawGizmos
+        {
+            get => drawGizmos;
+            set => drawGizmos = value;
+        }
+
         public void Solve()
         {
             if (root == null || mid == null || tip == null || target == null)
@@ -74,7 +128,7 @@ namespace jlinkdev.UnityUtilities.IK
             float cosAngle = ((upperLen * upperLen) + (clampedDist * clampedDist) - (lowerLen * lowerLen)) / (2f * upperLen * clampedDist);
             float angle = Mathf.Acos(Mathf.Clamp(cosAngle, -1f, 1f));
 
-            Vector3 bendDir = Quaternion.AngleAxis(-Mathf.Rad2Deg * angle, bendNormal) * dirToTarget;
+            Vector3 bendDir = Quaternion.AngleAxis(Mathf.Rad2Deg * angle, bendNormal) * dirToTarget;
             Vector3 solvedMidPos = rootPos + (bendDir * upperLen);
 
             Quaternion rootRotation = Quaternion.FromToRotation(midPos - rootPos, solvedMidPos - rootPos) * root.rotation;
@@ -124,7 +178,7 @@ namespace jlinkdev.UnityUtilities.IK
             if (pole != null)
             {
                 Gizmos.color = Color.magenta;
-                Gizmos.DrawLine(root.position, pole.position);
+                Gizmos.DrawLine(mid.position, pole.position);
                 Gizmos.DrawWireSphere(pole.position, 0.03f);
             }
         }

--- a/Runtime/IK/TwoBoneIK.cs.meta
+++ b/Runtime/IK/TwoBoneIK.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a226496a694251e4f88d9a384a7fcc57

--- a/Samples~/IK.meta
+++ b/Samples~/IK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e5d7e7f2ff24b4f9ff79012cad2dff5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/IK/README.md
+++ b/Samples~/IK/README.md
@@ -1,0 +1,33 @@
+# IK Sample
+
+This sample supports a runtime UI similar to the object pooling sample, but uses grid controls to move IK targets and pole hints.
+
+## Scene Setup
+
+Create one scene named `IK Demo` with separate station roots for the fixed controller stations:
+
+- `TwoBoneIK`: simple upper/mid/tip limb, one target grid, and one pole grid.
+- `FABRIKChain`: 4-6 joint chain, one target grid, and optionally one pole grid.
+- `AimIK`: turret, camera, or spine/neck chain with one target grid.
+- Optional `GroundProbe`: ray origin above uneven ground, with the probe transform used as a foot target.
+
+## Controller Setup
+
+1. Add an empty GameObject named `Demo Controller` and add `IKDemoController`.
+2. Assign the fixed `Two Bone`, `FABRIK`, `Aim`, and `Ground Probe` station groups you want to test.
+3. For each station you are testing, assign its optional station root, IK component, target grid, and optional pole grid.
+4. Add an empty GameObject named `Demo Overlay`, add `IKDemoOverlay`, and assign the controller.
+
+If `Show Only Active Station` is enabled, the controller will toggle station roots so only the selected station is visible.
+
+## Grid Setup
+
+For each target or pole:
+
+1. Create a visible target object, usually a small green sphere for targets or magenta cube for poles.
+2. Add `IKDemoTargetGrid` to a separate control object or directly to the target object.
+3. Assign the target transform.
+4. Assign an origin transform near the rig. If you leave origin empty, the grid captures a fallback origin from the target's current position.
+5. Choose the grid axes and cell size. A limb facing forward usually works well with horizontal `Vector3.right` and vertical `Vector3.up`.
+
+The overlay shows a 2D pad for each assigned target or pole grid. Dragging the pad point moves the target continuously and solves the active rig.

--- a/Samples~/IK/README.md.meta
+++ b/Samples~/IK/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 861bc07b863f445cbb3e2f3eb010a8ac
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/IK/Scripts.meta
+++ b/Samples~/IK/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce430492e852413c8d4a2bfe2d8f5ffd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/IK/Scripts/IKDemoController.cs
+++ b/Samples~/IK/Scripts/IKDemoController.cs
@@ -1,0 +1,648 @@
+using System;
+using jlinkdev.UnityUtilities.IK;
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.Samples.IK
+{
+    /// <summary>
+    /// Coordinates the fixed IK sample stations and exposes runtime controls for the demo overlay.
+    /// </summary>
+    public sealed class IKDemoController : MonoBehaviour
+    {
+        public enum StationId
+        {
+            TwoBone = 0,
+            FABRIK = 1,
+            Aim = 2,
+            GroundProbe = 3
+        }
+
+        public enum AimAxisOption
+        {
+            Forward,
+            Back,
+            Up,
+            Down,
+            Right,
+            Left,
+            Custom
+        }
+
+        [Serializable]
+        public sealed class TwoBoneStation
+        {
+            [SerializeField] [Tooltip("Name shown in the runtime overlay.")]
+            private string _displayName = "Two Bone Limb";
+            [SerializeField] [Tooltip("Optional scene root enabled for this station when only the active station is shown.")]
+            private GameObject _stationRoot;
+            [SerializeField] [Tooltip("Target grid used by this station.")]
+            private IKDemoTargetGrid _targetGrid;
+            [SerializeField] [Tooltip("Pole grid used by this station.")]
+            private IKDemoTargetGrid _poleGrid;
+            [SerializeField] [Tooltip("TwoBoneIK component controlled by this station.")]
+            private TwoBoneIK _twoBoneIK;
+
+            public string DisplayName => ResolveName(_displayName, "Two Bone Limb");
+            public GameObject StationRoot => _stationRoot;
+            public IKDemoTargetGrid TargetGrid => _targetGrid;
+            public IKDemoTargetGrid PoleGrid => _poleGrid;
+            public TwoBoneIK TwoBoneIK => _twoBoneIK;
+        }
+
+        [Serializable]
+        public sealed class FABRIKStation
+        {
+            [SerializeField] [Tooltip("Name shown in the runtime overlay.")]
+            private string _displayName = "FABRIK Chain";
+            [SerializeField] [Tooltip("Optional scene root enabled for this station when only the active station is shown.")]
+            private GameObject _stationRoot;
+            [SerializeField] [Tooltip("Target grid used by this station.")]
+            private IKDemoTargetGrid _targetGrid;
+            [SerializeField] [Tooltip("Optional pole grid used by this station.")]
+            private IKDemoTargetGrid _poleGrid;
+            [SerializeField] [Tooltip("FABRIKChain component controlled by this station.")]
+            private FABRIKChain _fabrikChain;
+
+            public string DisplayName => ResolveName(_displayName, "FABRIK Chain");
+            public GameObject StationRoot => _stationRoot;
+            public IKDemoTargetGrid TargetGrid => _targetGrid;
+            public IKDemoTargetGrid PoleGrid => _poleGrid;
+            public FABRIKChain FABRIKChain => _fabrikChain;
+        }
+
+        [Serializable]
+        public sealed class AimStation
+        {
+            [SerializeField] [Tooltip("Name shown in the runtime overlay.")]
+            private string _displayName = "Aim IK";
+            [SerializeField] [Tooltip("Optional scene root enabled for this station when only the active station is shown.")]
+            private GameObject _stationRoot;
+            [SerializeField] [Tooltip("Target grid used by this station.")]
+            private IKDemoTargetGrid _targetGrid;
+            [SerializeField] [Tooltip("AimIK component controlled by this station.")]
+            private AimIK _aimIK;
+
+            public string DisplayName => ResolveName(_displayName, "Aim IK");
+            public GameObject StationRoot => _stationRoot;
+            public IKDemoTargetGrid TargetGrid => _targetGrid;
+            public AimIK AimIK => _aimIK;
+        }
+
+        [Serializable]
+        public sealed class GroundProbeStation
+        {
+            [SerializeField] [Tooltip("Name shown in the runtime overlay.")]
+            private string _displayName = "Ground Probe";
+            [SerializeField] [Tooltip("Optional scene root enabled for this station when only the active station is shown.")]
+            private GameObject _stationRoot;
+            [SerializeField] [Tooltip("Grid used to move the ray origin or other probe-driving target.")]
+            private IKDemoTargetGrid _targetGrid;
+            [SerializeField] [Tooltip("Optional TwoBoneIK component controlled by this station.")]
+            private TwoBoneIK _twoBoneIK;
+            [SerializeField] [Tooltip("GroundProbe component controlled by this station.")]
+            private GroundProbe _groundProbe;
+
+            public string DisplayName => ResolveName(_displayName, "Ground Probe");
+            public GameObject StationRoot => _stationRoot;
+            public IKDemoTargetGrid TargetGrid => _targetGrid;
+            public TwoBoneIK TwoBoneIK => _twoBoneIK;
+            public GroundProbe GroundProbe => _groundProbe;
+        }
+
+        [Header("Stations")]
+        [SerializeField] private TwoBoneStation _twoBone = new TwoBoneStation();
+        [SerializeField] private FABRIKStation _fabrik = new FABRIKStation();
+        [SerializeField] private AimStation _aim = new AimStation();
+        [SerializeField] private GroundProbeStation _groundProbe = new GroundProbeStation();
+
+        [Header("State")]
+        [SerializeField] [Tooltip("Initial active station.")]
+        private StationId _activeStation = StationId.TwoBone;
+        [SerializeField] [Tooltip("Enable only the active station root while the demo runs.")]
+        private bool _showOnlyActiveStation = true;
+
+        public int StationCount => 4;
+        public int ActiveStationIndex => (int)_activeStation;
+        public StationId ActiveStation => _activeStation;
+        public IKDemoTargetGrid CurrentTargetGrid => GetCurrentTargetGrid();
+        public IKDemoTargetGrid CurrentPoleGrid => GetCurrentPoleGrid();
+        public string CurrentStationName => GetStationName(ActiveStationIndex);
+        public string CurrentStationDescription => GetStationDescription(_activeStation);
+
+        public bool CurrentHasWeight => GetCurrentTwoBone() != null || GetCurrentFABRIK() != null || GetCurrentAim() != null;
+        public bool CurrentHasIterations => GetCurrentFABRIK() != null || GetCurrentAim() != null;
+        public bool CurrentHasLockRoot => GetCurrentFABRIK() != null;
+        public bool CurrentHasMatchTipRotation => GetCurrentTwoBone() != null;
+        public bool CurrentHasAimAxis => GetCurrentAim() != null;
+        public bool CurrentHasGroundProbe => GetCurrentGroundProbe() != null;
+
+        private void Awake()
+        {
+            ApplyActiveStationVisibility();
+            ApplyCurrentGridPositions();
+        }
+
+        public string GetStationName(int index)
+        {
+            switch ((StationId)Mathf.Clamp(index, 0, StationCount - 1))
+            {
+                case StationId.TwoBone:
+                    return _twoBone.DisplayName;
+                case StationId.FABRIK:
+                    return _fabrik.DisplayName;
+                case StationId.Aim:
+                    return _aim.DisplayName;
+                case StationId.GroundProbe:
+                    return _groundProbe.DisplayName;
+                default:
+                    return "Station";
+            }
+        }
+
+        private string GetStationDescription(StationId station)
+        {
+            switch (station)
+            {
+                case StationId.TwoBone:
+                    return "TwoBoneIK solves a three-joint limb toward a target. The pole controls the bend direction, while weight blends the result and match tip rotation can align the tip to the target.";
+                case StationId.FABRIK:
+                    return "FABRIKChain solves a longer joint chain from root to tip. Iterations control solve quality, lock root keeps the chain anchored, and an optional pole biases the bend direction.";
+                case StationId.Aim:
+                    return "AimIK rotates a joint chain so the configured local aim axis points at the target. Use it for turrets, cameras, heads, or other look-at style rigs.";
+                case StationId.GroundProbe:
+                    return "GroundProbe raycasts downward from an origin and moves its transform to the hit surface. Use it as a foot target for terrain-aware limb placement.";
+                default:
+                    return string.Empty;
+            }
+        }
+
+        public void SetActiveStation(int index)
+        {
+            StationId nextStation = (StationId)Mathf.Clamp(index, 0, StationCount - 1);
+            if (_activeStation == nextStation)
+            {
+                ApplyCurrentGridPositions();
+                return;
+            }
+
+            _activeStation = nextStation;
+            ApplyActiveStationVisibility();
+            ApplyCurrentGridPositions();
+            SolveCurrent();
+        }
+
+        public void SetCurrentTargetCell(int column, int row)
+        {
+            if (CurrentTargetGrid == null)
+            {
+                return;
+            }
+
+            CurrentTargetGrid.SetCell(column, row);
+            SolveCurrent();
+        }
+
+        public void SetCurrentTargetNormalizedPosition(Vector2 normalizedPosition)
+        {
+            if (CurrentTargetGrid == null)
+            {
+                return;
+            }
+
+            CurrentTargetGrid.SetNormalizedPosition(normalizedPosition);
+            SolveCurrent();
+        }
+
+        public void CenterCurrentTarget()
+        {
+            if (CurrentTargetGrid == null)
+            {
+                return;
+            }
+
+            CurrentTargetGrid.Center();
+            SolveCurrent();
+        }
+
+        public void SetCurrentPoleCell(int column, int row)
+        {
+            if (CurrentPoleGrid == null)
+            {
+                return;
+            }
+
+            CurrentPoleGrid.SetCell(column, row);
+            SolveCurrent();
+        }
+
+        public void SetCurrentPoleNormalizedPosition(Vector2 normalizedPosition)
+        {
+            if (CurrentPoleGrid == null)
+            {
+                return;
+            }
+
+            CurrentPoleGrid.SetNormalizedPosition(normalizedPosition);
+            SolveCurrent();
+        }
+
+        public void CenterCurrentPole()
+        {
+            if (CurrentPoleGrid == null)
+            {
+                return;
+            }
+
+            CurrentPoleGrid.Center();
+            SolveCurrent();
+        }
+
+        public float CurrentWeight
+        {
+            get
+            {
+                TwoBoneIK twoBone = GetCurrentTwoBone();
+                if (twoBone != null)
+                {
+                    return twoBone.Weight;
+                }
+
+                FABRIKChain fabrik = GetCurrentFABRIK();
+                if (fabrik != null)
+                {
+                    return fabrik.Weight;
+                }
+
+                AimIK aim = GetCurrentAim();
+                return aim != null ? aim.Weight : 0f;
+            }
+            set
+            {
+                float clampedValue = Mathf.Clamp01(value);
+                TwoBoneIK twoBone = GetCurrentTwoBone();
+                if (twoBone != null)
+                {
+                    twoBone.Weight = clampedValue;
+                    SolveCurrent();
+                    return;
+                }
+
+                FABRIKChain fabrik = GetCurrentFABRIK();
+                if (fabrik != null)
+                {
+                    fabrik.Weight = clampedValue;
+                    SolveCurrent();
+                    return;
+                }
+
+                AimIK aim = GetCurrentAim();
+                if (aim != null)
+                {
+                    aim.Weight = clampedValue;
+                    SolveCurrent();
+                }
+            }
+        }
+
+        public bool CurrentMatchTipRotation
+        {
+            get
+            {
+                TwoBoneIK twoBone = GetCurrentTwoBone();
+                return twoBone != null && twoBone.MatchTipRotation;
+            }
+            set
+            {
+                TwoBoneIK twoBone = GetCurrentTwoBone();
+                if (twoBone == null)
+                {
+                    return;
+                }
+
+                twoBone.MatchTipRotation = value;
+                SolveCurrent();
+            }
+        }
+
+        public int CurrentIterations
+        {
+            get
+            {
+                FABRIKChain fabrik = GetCurrentFABRIK();
+                if (fabrik != null)
+                {
+                    return fabrik.Iterations;
+                }
+
+                AimIK aim = GetCurrentAim();
+                return aim != null ? aim.Iterations : 1;
+            }
+            set
+            {
+                int clampedValue = Mathf.Max(1, value);
+                FABRIKChain fabrik = GetCurrentFABRIK();
+                if (fabrik != null)
+                {
+                    fabrik.Iterations = clampedValue;
+                    SolveCurrent();
+                    return;
+                }
+
+                AimIK aim = GetCurrentAim();
+                if (aim != null)
+                {
+                    aim.Iterations = clampedValue;
+                    SolveCurrent();
+                }
+            }
+        }
+
+        public bool CurrentLockRoot
+        {
+            get
+            {
+                FABRIKChain fabrik = GetCurrentFABRIK();
+                return fabrik != null && fabrik.LockRoot;
+            }
+            set
+            {
+                FABRIKChain fabrik = GetCurrentFABRIK();
+                if (fabrik == null)
+                {
+                    return;
+                }
+
+                fabrik.LockRoot = value;
+                SolveCurrent();
+            }
+        }
+
+        public AimAxisOption CurrentAimAxis
+        {
+            get
+            {
+                AimIK aim = GetCurrentAim();
+                if (aim == null)
+                {
+                    return AimAxisOption.Custom;
+                }
+
+                Vector3 axis = aim.LocalAimAxis;
+                if (IsAxis(axis, Vector3.forward)) return AimAxisOption.Forward;
+                if (IsAxis(axis, Vector3.back)) return AimAxisOption.Back;
+                if (IsAxis(axis, Vector3.up)) return AimAxisOption.Up;
+                if (IsAxis(axis, Vector3.down)) return AimAxisOption.Down;
+                if (IsAxis(axis, Vector3.right)) return AimAxisOption.Right;
+                if (IsAxis(axis, Vector3.left)) return AimAxisOption.Left;
+                return AimAxisOption.Custom;
+            }
+            set
+            {
+                AimIK aim = GetCurrentAim();
+                if (aim == null || value == AimAxisOption.Custom)
+                {
+                    return;
+                }
+
+                aim.LocalAimAxis = AimAxisToVector(value);
+                SolveCurrent();
+            }
+        }
+
+        public float CurrentGroundRayDistance
+        {
+            get
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                return groundProbe != null ? groundProbe.RayDistance : 0f;
+            }
+            set
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                if (groundProbe != null)
+                {
+                    groundProbe.RayDistance = value;
+                }
+            }
+        }
+
+        public float CurrentGroundSurfaceOffset
+        {
+            get
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                return groundProbe != null ? groundProbe.SurfaceOffset : 0f;
+            }
+            set
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                if (groundProbe != null)
+                {
+                    groundProbe.SurfaceOffset = value;
+                }
+            }
+        }
+
+        public bool CurrentGroundAlignToNormal
+        {
+            get
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                return groundProbe != null && groundProbe.AlignToNormal;
+            }
+            set
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                if (groundProbe != null)
+                {
+                    groundProbe.AlignToNormal = value;
+                }
+            }
+        }
+
+        public float CurrentGroundPositionSmooth
+        {
+            get
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                return groundProbe != null ? groundProbe.PositionSmooth : 0f;
+            }
+            set
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                if (groundProbe != null)
+                {
+                    groundProbe.PositionSmooth = value;
+                }
+            }
+        }
+
+        public float CurrentGroundRotationSmooth
+        {
+            get
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                return groundProbe != null ? groundProbe.RotationSmooth : 0f;
+            }
+            set
+            {
+                GroundProbe groundProbe = GetCurrentGroundProbe();
+                if (groundProbe != null)
+                {
+                    groundProbe.RotationSmooth = value;
+                }
+            }
+        }
+
+        public void SolveCurrent()
+        {
+            TwoBoneIK twoBone = GetCurrentTwoBone();
+            if (twoBone != null)
+            {
+                twoBone.Solve();
+                return;
+            }
+
+            FABRIKChain fabrik = GetCurrentFABRIK();
+            if (fabrik != null)
+            {
+                fabrik.Solve();
+                return;
+            }
+
+            AimIK aim = GetCurrentAim();
+            if (aim != null)
+            {
+                aim.Solve();
+            }
+        }
+
+        private void ApplyActiveStationVisibility()
+        {
+            if (!_showOnlyActiveStation)
+            {
+                return;
+            }
+
+            SetStationRootActive(_twoBone.StationRoot, _activeStation == StationId.TwoBone);
+            SetStationRootActive(_fabrik.StationRoot, _activeStation == StationId.FABRIK);
+            SetStationRootActive(_aim.StationRoot, _activeStation == StationId.Aim);
+            SetStationRootActive(_groundProbe.StationRoot, _activeStation == StationId.GroundProbe);
+        }
+
+        private void ApplyCurrentGridPositions()
+        {
+            if (CurrentTargetGrid != null)
+            {
+                CurrentTargetGrid.ApplyPosition();
+            }
+
+            if (CurrentPoleGrid != null)
+            {
+                CurrentPoleGrid.ApplyPosition();
+            }
+        }
+
+        private IKDemoTargetGrid GetCurrentTargetGrid()
+        {
+            switch (_activeStation)
+            {
+                case StationId.TwoBone:
+                    return _twoBone.TargetGrid;
+                case StationId.FABRIK:
+                    return _fabrik.TargetGrid;
+                case StationId.Aim:
+                    return _aim.TargetGrid;
+                case StationId.GroundProbe:
+                    return _groundProbe.TargetGrid;
+                default:
+                    return null;
+            }
+        }
+
+        private IKDemoTargetGrid GetCurrentPoleGrid()
+        {
+            switch (_activeStation)
+            {
+                case StationId.TwoBone:
+                    return _twoBone.PoleGrid;
+                case StationId.FABRIK:
+                    return _fabrik.PoleGrid;
+                default:
+                    return null;
+            }
+        }
+
+        private TwoBoneIK GetCurrentTwoBone()
+        {
+            switch (_activeStation)
+            {
+                case StationId.TwoBone:
+                    return _twoBone.TwoBoneIK;
+                case StationId.GroundProbe:
+                    return _groundProbe.TwoBoneIK;
+                default:
+                    return null;
+            }
+        }
+
+        private FABRIKChain GetCurrentFABRIK()
+        {
+            return _activeStation == StationId.FABRIK ? _fabrik.FABRIKChain : null;
+        }
+
+        private AimIK GetCurrentAim()
+        {
+            return _activeStation == StationId.Aim ? _aim.AimIK : null;
+        }
+
+        private GroundProbe GetCurrentGroundProbe()
+        {
+            return _activeStation == StationId.GroundProbe ? _groundProbe.GroundProbe : null;
+        }
+
+        private static void SetStationRootActive(GameObject stationRoot, bool active)
+        {
+            if (stationRoot != null)
+            {
+                stationRoot.SetActive(active);
+            }
+        }
+
+        private static string ResolveName(string displayName, string fallback)
+        {
+            return string.IsNullOrEmpty(displayName) ? fallback : displayName.Trim();
+        }
+
+        private static bool IsAxis(Vector3 value, Vector3 axis)
+        {
+            if (value.sqrMagnitude <= 0.00001f)
+            {
+                return false;
+            }
+
+            return Vector3.Dot(value.normalized, axis.normalized) > 0.999f;
+        }
+
+        private static Vector3 AimAxisToVector(AimAxisOption axis)
+        {
+            switch (axis)
+            {
+                case AimAxisOption.Forward:
+                    return Vector3.forward;
+                case AimAxisOption.Back:
+                    return Vector3.back;
+                case AimAxisOption.Up:
+                    return Vector3.up;
+                case AimAxisOption.Down:
+                    return Vector3.down;
+                case AimAxisOption.Right:
+                    return Vector3.right;
+                case AimAxisOption.Left:
+                    return Vector3.left;
+                default:
+                    return Vector3.forward;
+            }
+        }
+    }
+}

--- a/Samples~/IK/Scripts/IKDemoController.cs.meta
+++ b/Samples~/IK/Scripts/IKDemoController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d32173b68ef84ac38b6df1e9f5855ea5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/IK/Scripts/IKDemoOverlay.cs
+++ b/Samples~/IK/Scripts/IKDemoOverlay.cs
@@ -1,0 +1,315 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.Samples.IK
+{
+    /// <summary>
+    /// Lightweight runtime controls for the IK sample scene.
+    /// </summary>
+    public sealed class IKDemoOverlay : MonoBehaviour
+    {
+        [SerializeField] [Tooltip("Demo controller that receives overlay actions.")]
+        private IKDemoController _controller;
+        [SerializeField] [Tooltip("Initial position and size of the runtime overlay window.")]
+        private Rect _windowRect = new Rect(16f, 16f, 420f, 680f);
+        [SerializeField] [Tooltip("Pixel size for 2D target pads.")]
+        private float _padSize = 180f;
+
+        private void OnGUI()
+        {
+            _windowRect = GUILayout.Window(GetInstanceID(), _windowRect, DrawWindow, "IK Demo");
+        }
+
+        private void DrawWindow(int windowId)
+        {
+            if (_controller == null)
+            {
+                GUILayout.Label("Assign IKDemoController.");
+                GUI.DragWindow();
+                return;
+            }
+
+            DrawStationButtons();
+            DrawDescription();
+            GUILayout.Space(6f);
+
+            DrawGrid("Target Grid", _controller.CurrentTargetGrid, false);
+            DrawGrid("Pole Grid", _controller.CurrentPoleGrid, true);
+            DrawSolverControls();
+
+            GUI.DragWindow();
+        }
+
+        private void DrawDescription()
+        {
+            if (string.IsNullOrEmpty(_controller.CurrentStationDescription))
+            {
+                return;
+            }
+
+            GUIStyle wrappedLabel = new GUIStyle(GUI.skin.label)
+            {
+                wordWrap = true
+            };
+
+            GUILayout.Space(4f);
+            GUILayout.Label(_controller.CurrentStationDescription, wrappedLabel);
+        }
+
+        private void DrawStationButtons()
+        {
+            if (_controller.StationCount <= 0)
+            {
+                GUILayout.Label("No stations assigned.");
+                return;
+            }
+
+            GUILayout.Label("Station");
+            for (int i = 0; i < _controller.StationCount; i++)
+            {
+                string stationName = _controller.GetStationName(i);
+                bool isActive = i == _controller.ActiveStationIndex;
+                bool nextActive = GUILayout.Toggle(isActive, stationName, GUI.skin.button);
+                if (nextActive && !isActive)
+                {
+                    _controller.SetActiveStation(i);
+                }
+            }
+        }
+
+        private void DrawGrid(string title, IKDemoTargetGrid grid, bool poleGrid)
+        {
+            if (grid == null)
+            {
+                return;
+            }
+
+            GUILayout.BeginVertical(GUI.skin.box);
+            GUILayout.Label(title);
+
+            DrawPositionPad(grid, poleGrid);
+            GUILayout.EndVertical();
+        }
+
+        private void DrawPositionPad(IKDemoTargetGrid grid, bool poleGrid)
+        {
+            float padSize = Mathf.Max(80f, _padSize);
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            Rect rect = GUILayoutUtility.GetRect(padSize, padSize, GUILayout.Width(padSize), GUILayout.Height(padSize));
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            int controlId = GUIUtility.GetControlID((poleGrid ? "PolePad" : "TargetPad").GetHashCode(), FocusType.Passive, rect);
+            Event currentEvent = Event.current;
+
+            if ((currentEvent.type == EventType.MouseDown || currentEvent.type == EventType.MouseDrag) &&
+                (rect.Contains(currentEvent.mousePosition) || GUIUtility.hotControl == controlId))
+            {
+                GUIUtility.hotControl = controlId;
+                Vector2 normalizedPosition = MouseToNormalizedPosition(rect, currentEvent.mousePosition);
+                if (poleGrid)
+                {
+                    _controller.SetCurrentPoleNormalizedPosition(normalizedPosition);
+                }
+                else
+                {
+                    _controller.SetCurrentTargetNormalizedPosition(normalizedPosition);
+                }
+
+                currentEvent.Use();
+            }
+            else if (currentEvent.type == EventType.MouseUp && GUIUtility.hotControl == controlId)
+            {
+                GUIUtility.hotControl = 0;
+                currentEvent.Use();
+            }
+
+            DrawPad(rect, grid, poleGrid);
+        }
+
+        private void DrawPad(Rect rect, IKDemoTargetGrid grid, bool poleGrid)
+        {
+            Color previousColor = GUI.color;
+            Color previousBackground = GUI.backgroundColor;
+
+            GUI.backgroundColor = new Color(0.12f, 0.12f, 0.12f, 1f);
+            GUI.Box(rect, GUIContent.none);
+
+            Color lineColor = new Color(1f, 1f, 1f, 0.22f);
+            DrawLine(new Vector2(rect.xMin, rect.center.y), new Vector2(rect.xMax, rect.center.y), lineColor, 1f);
+            DrawLine(new Vector2(rect.center.x, rect.yMin), new Vector2(rect.center.x, rect.yMax), lineColor, 1f);
+
+            for (int column = 1; column < grid.Columns - 1; column++)
+            {
+                float x = Mathf.Lerp(rect.xMin, rect.xMax, column / (float)(grid.Columns - 1));
+                DrawLine(new Vector2(x, rect.yMin), new Vector2(x, rect.yMax), new Color(1f, 1f, 1f, 0.08f), 1f);
+            }
+
+            for (int row = 1; row < grid.Rows - 1; row++)
+            {
+                float y = Mathf.Lerp(rect.yMax, rect.yMin, row / (float)(grid.Rows - 1));
+                DrawLine(new Vector2(rect.xMin, y), new Vector2(rect.xMax, y), new Color(1f, 1f, 1f, 0.08f), 1f);
+            }
+
+            Vector2 point = NormalizedToPadPosition(rect, grid.NormalizedPosition);
+            Rect pointRect = new Rect(point.x - 6f, point.y - 6f, 12f, 12f);
+            GUI.color = poleGrid ? new Color(1f, 0.35f, 1f, 1f) : new Color(0.35f, 1f, 0.45f, 1f);
+            GUI.DrawTexture(pointRect, Texture2D.whiteTexture);
+
+            GUI.color = previousColor;
+            GUI.backgroundColor = previousBackground;
+        }
+
+        private static Vector2 MouseToNormalizedPosition(Rect rect, Vector2 mousePosition)
+        {
+            float x = Mathf.InverseLerp(rect.xMin, rect.xMax, mousePosition.x) * 2f - 1f;
+            float y = Mathf.InverseLerp(rect.yMax, rect.yMin, mousePosition.y) * 2f - 1f;
+            return new Vector2(Mathf.Clamp(x, -1f, 1f), Mathf.Clamp(y, -1f, 1f));
+        }
+
+        private static Vector2 NormalizedToPadPosition(Rect rect, Vector2 normalizedPosition)
+        {
+            float x = Mathf.Lerp(rect.xMin, rect.xMax, (normalizedPosition.x + 1f) * 0.5f);
+            float y = Mathf.Lerp(rect.yMax, rect.yMin, (normalizedPosition.y + 1f) * 0.5f);
+            return new Vector2(x, y);
+        }
+
+        private static void DrawLine(Vector2 start, Vector2 end, Color color, float width)
+        {
+            Matrix4x4 previousMatrix = GUI.matrix;
+            Color previousColor = GUI.color;
+
+            Vector2 delta = end - start;
+            float angle = Mathf.Atan2(delta.y, delta.x) * Mathf.Rad2Deg;
+            GUI.color = color;
+            GUIUtility.RotateAroundPivot(angle, start);
+            GUI.DrawTexture(new Rect(start.x, start.y - (width * 0.5f), delta.magnitude, width), Texture2D.whiteTexture);
+
+            GUI.matrix = previousMatrix;
+            GUI.color = previousColor;
+        }
+
+        private void DrawSolverControls()
+        {
+            GUILayout.BeginVertical(GUI.skin.box);
+            GUILayout.Label("Solver Controls");
+
+            if (_controller.CurrentHasWeight)
+            {
+                float nextWeight = DrawSlider("Weight", _controller.CurrentWeight, 0f, 1f);
+                if (!Mathf.Approximately(nextWeight, _controller.CurrentWeight))
+                {
+                    _controller.CurrentWeight = nextWeight;
+                }
+            }
+
+            if (_controller.CurrentHasMatchTipRotation)
+            {
+                bool nextMatchTipRotation = GUILayout.Toggle(_controller.CurrentMatchTipRotation, "Match tip rotation");
+                if (nextMatchTipRotation != _controller.CurrentMatchTipRotation)
+                {
+                    _controller.CurrentMatchTipRotation = nextMatchTipRotation;
+                }
+            }
+
+            if (_controller.CurrentHasIterations)
+            {
+                int nextIterations = Mathf.RoundToInt(DrawSlider("Iterations", _controller.CurrentIterations, 1f, 24f));
+                if (nextIterations != _controller.CurrentIterations)
+                {
+                    _controller.CurrentIterations = nextIterations;
+                }
+            }
+
+            if (_controller.CurrentHasLockRoot)
+            {
+                bool nextLockRoot = GUILayout.Toggle(_controller.CurrentLockRoot, "Lock root");
+                if (nextLockRoot != _controller.CurrentLockRoot)
+                {
+                    _controller.CurrentLockRoot = nextLockRoot;
+                }
+            }
+
+            if (_controller.CurrentHasAimAxis)
+            {
+                DrawAimAxisControls();
+            }
+
+            if (_controller.CurrentHasGroundProbe)
+            {
+                DrawGroundProbeControls();
+            }
+
+            GUILayout.EndVertical();
+        }
+
+        private void DrawAimAxisControls()
+        {
+            GUILayout.Label($"Aim axis: {_controller.CurrentAimAxis}");
+            GUILayout.BeginHorizontal();
+            DrawAimAxisButton(IKDemoController.AimAxisOption.Forward, "Forward");
+            DrawAimAxisButton(IKDemoController.AimAxisOption.Up, "Up");
+            DrawAimAxisButton(IKDemoController.AimAxisOption.Right, "Right");
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            DrawAimAxisButton(IKDemoController.AimAxisOption.Back, "Back");
+            DrawAimAxisButton(IKDemoController.AimAxisOption.Down, "Down");
+            DrawAimAxisButton(IKDemoController.AimAxisOption.Left, "Left");
+            GUILayout.EndHorizontal();
+        }
+
+        private void DrawAimAxisButton(IKDemoController.AimAxisOption axis, string label)
+        {
+            bool selected = _controller.CurrentAimAxis == axis;
+            bool nextSelected = GUILayout.Toggle(selected, label, GUI.skin.button);
+            if (nextSelected && !selected)
+            {
+                _controller.CurrentAimAxis = axis;
+            }
+        }
+
+        private void DrawGroundProbeControls()
+        {
+            float nextRayDistance = DrawSlider("Ray distance", _controller.CurrentGroundRayDistance, 0.1f, 5f);
+            if (!Mathf.Approximately(nextRayDistance, _controller.CurrentGroundRayDistance))
+            {
+                _controller.CurrentGroundRayDistance = nextRayDistance;
+            }
+
+            float nextSurfaceOffset = DrawSlider("Surface offset", _controller.CurrentGroundSurfaceOffset, 0f, 0.5f);
+            if (!Mathf.Approximately(nextSurfaceOffset, _controller.CurrentGroundSurfaceOffset))
+            {
+                _controller.CurrentGroundSurfaceOffset = nextSurfaceOffset;
+            }
+
+            float nextPositionSmooth = DrawSlider("Position smooth", _controller.CurrentGroundPositionSmooth, 0f, 30f);
+            if (!Mathf.Approximately(nextPositionSmooth, _controller.CurrentGroundPositionSmooth))
+            {
+                _controller.CurrentGroundPositionSmooth = nextPositionSmooth;
+            }
+
+            float nextRotationSmooth = DrawSlider("Rotation smooth", _controller.CurrentGroundRotationSmooth, 0f, 30f);
+            if (!Mathf.Approximately(nextRotationSmooth, _controller.CurrentGroundRotationSmooth))
+            {
+                _controller.CurrentGroundRotationSmooth = nextRotationSmooth;
+            }
+
+            bool nextAlignToNormal = GUILayout.Toggle(_controller.CurrentGroundAlignToNormal, "Align to normal");
+            if (nextAlignToNormal != _controller.CurrentGroundAlignToNormal)
+            {
+                _controller.CurrentGroundAlignToNormal = nextAlignToNormal;
+            }
+        }
+
+        private float DrawSlider(string label, float value, float min, float max)
+        {
+            GUILayout.BeginHorizontal();
+            GUILayout.Label($"{label}: {value:0.00}", GUILayout.Width(145f));
+            float nextValue = GUILayout.HorizontalSlider(value, min, max);
+            GUILayout.EndHorizontal();
+            return nextValue;
+        }
+
+    }
+}

--- a/Samples~/IK/Scripts/IKDemoOverlay.cs.meta
+++ b/Samples~/IK/Scripts/IKDemoOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6d5ef9b1d9b4191bc1310df141d055a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/IK/Scripts/IKDemoRendererTint.cs
+++ b/Samples~/IK/Scripts/IKDemoRendererTint.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.Samples.IK
+{
+    /// <summary>
+    /// Applies a simple color override to demo renderers without needing material assets.
+    /// </summary>
+    public sealed class IKDemoRendererTint : MonoBehaviour
+    {
+        private static readonly int ColorId = Shader.PropertyToID("_Color");
+        private static readonly int BaseColorId = Shader.PropertyToID("_BaseColor");
+
+        [SerializeField] [Tooltip("Renderer to tint. Uses a renderer on this object when left empty.")]
+        private Renderer _renderer;
+        [SerializeField] [Tooltip("Color applied through a material property block.")]
+        private Color _color = Color.white;
+
+        private MaterialPropertyBlock _propertyBlock;
+
+        private void Awake()
+        {
+            Apply();
+        }
+
+        private void OnValidate()
+        {
+            Apply();
+        }
+
+        public void Apply()
+        {
+            if (_renderer == null)
+            {
+                _renderer = GetComponent<Renderer>();
+            }
+
+            if (_renderer == null)
+            {
+                return;
+            }
+
+            if (_propertyBlock == null)
+            {
+                _propertyBlock = new MaterialPropertyBlock();
+            }
+
+            _renderer.GetPropertyBlock(_propertyBlock);
+            _propertyBlock.SetColor(ColorId, _color);
+            _propertyBlock.SetColor(BaseColorId, _color);
+            _renderer.SetPropertyBlock(_propertyBlock);
+        }
+    }
+}

--- a/Samples~/IK/Scripts/IKDemoRendererTint.cs.meta
+++ b/Samples~/IK/Scripts/IKDemoRendererTint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9dbed622492d4b23ac7d745827c42b8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/IK/Scripts/IKDemoTargetGrid.cs
+++ b/Samples~/IK/Scripts/IKDemoTargetGrid.cs
@@ -1,0 +1,276 @@
+using UnityEngine;
+
+namespace jlinkdev.UnityUtilities.Samples.IK
+{
+    /// <summary>
+    /// Places an IK target on a simple configurable grid for sample scene controls.
+    /// </summary>
+    public sealed class IKDemoTargetGrid : MonoBehaviour
+    {
+        [Header("Target")]
+        [SerializeField] [Tooltip("Transform moved by the grid. Uses this transform when left empty.")]
+        private Transform _target;
+        [SerializeField] [Tooltip("Optional transform used as the grid origin.")]
+        private Transform _origin;
+        [SerializeField] [Tooltip("Offset from the grid origin before cell offsets are applied.")]
+        private Vector3 _originOffset;
+
+        [Header("Grid")]
+        [SerializeField] [Tooltip("Number of horizontal cells.")]
+        [Min(1)]
+        private int _columns = 5;
+        [SerializeField] [Tooltip("Number of vertical cells.")]
+        [Min(1)]
+        private int _rows = 5;
+        [SerializeField] [Tooltip("Distance between adjacent grid cells in world units.")]
+        [Min(0.01f)]
+        private float _cellSize = 0.5f;
+        [SerializeField] [Tooltip("Current horizontal cell index.")]
+        private int _column = 2;
+        [SerializeField] [Tooltip("Current vertical cell index.")]
+        private int _row = 2;
+        [SerializeField] [Tooltip("Continuous grid position from -1 to 1 on each axis.")]
+        private Vector2 _normalizedPosition;
+
+        [Header("Axes")]
+        [SerializeField] [Tooltip("Horizontal grid axis. If an origin is assigned, this can be interpreted in origin-local space.")]
+        private Vector3 _horizontalAxis = Vector3.right;
+        [SerializeField] [Tooltip("Vertical grid axis. If an origin is assigned, this can be interpreted in origin-local space.")]
+        private Vector3 _verticalAxis = Vector3.up;
+        [SerializeField] [Tooltip("Use the origin rotation when resolving grid axes.")]
+        private bool _useOriginRotation = true;
+
+        [Header("Debug")]
+        [SerializeField] [Tooltip("Draw the grid in the scene view when selected.")]
+        private bool _drawGizmos = true;
+        [SerializeField] [Tooltip("Scene view gizmo color for this grid.")]
+        private Color _gizmoColor = new Color(0.2f, 1f, 0.45f, 0.75f);
+        [SerializeField, HideInInspector]
+        private bool _hasFallbackOriginPosition;
+        [SerializeField, HideInInspector]
+        private Vector3 _fallbackOriginPosition;
+
+        public Transform Target
+        {
+            get => _target != null ? _target : transform;
+            set
+            {
+                _target = value;
+                ApplyPosition();
+            }
+        }
+
+        public Transform Origin
+        {
+            get => _origin;
+            set
+            {
+                _origin = value;
+                ApplyPosition();
+            }
+        }
+
+        public int Columns
+        {
+            get => Mathf.Max(1, _columns);
+            set
+            {
+                _columns = Mathf.Max(1, value);
+                ClampCell();
+                ApplyPosition();
+            }
+        }
+
+        public int Rows
+        {
+            get => Mathf.Max(1, _rows);
+            set
+            {
+                _rows = Mathf.Max(1, value);
+                ClampCell();
+                ApplyPosition();
+            }
+        }
+
+        public int Column => Mathf.RoundToInt(Mathf.Lerp(0f, Columns - 1, (_normalizedPosition.x + 1f) * 0.5f));
+        public int Row => Mathf.RoundToInt(Mathf.Lerp(0f, Rows - 1, (_normalizedPosition.y + 1f) * 0.5f));
+        public float CellSize => _cellSize;
+        public Vector2 NormalizedPosition => _normalizedPosition;
+        public Vector3 TargetPosition => ResolvePosition();
+
+        private void OnEnable()
+        {
+            ApplyPosition();
+        }
+
+        private void OnValidate()
+        {
+            _columns = Mathf.Max(1, _columns);
+            _rows = Mathf.Max(1, _rows);
+            _cellSize = Mathf.Max(0.01f, _cellSize);
+            _normalizedPosition.x = Mathf.Clamp(_normalizedPosition.x, -1f, 1f);
+            _normalizedPosition.y = Mathf.Clamp(_normalizedPosition.y, -1f, 1f);
+            ClampCell();
+            ApplyPosition();
+        }
+
+        public void SetCell(int column, int row)
+        {
+            _column = Mathf.Clamp(column, 0, Columns - 1);
+            _row = Mathf.Clamp(row, 0, Rows - 1);
+            _normalizedPosition = CellToNormalizedPosition(_column, _row);
+            ApplyPosition();
+        }
+
+        public void MoveCell(int columnDelta, int rowDelta)
+        {
+            SetCell(_column + columnDelta, _row + rowDelta);
+        }
+
+        public void Center()
+        {
+            SetNormalizedPosition(Vector2.zero);
+        }
+
+        public void SetNormalizedPosition(Vector2 normalizedPosition)
+        {
+            _normalizedPosition.x = Mathf.Clamp(normalizedPosition.x, -1f, 1f);
+            _normalizedPosition.y = Mathf.Clamp(normalizedPosition.y, -1f, 1f);
+            _column = Column;
+            _row = Row;
+            ApplyPosition();
+        }
+
+        public void CaptureOriginFromTarget()
+        {
+            CaptureFallbackOriginPosition();
+            ApplyPosition();
+        }
+
+        public void ApplyPosition()
+        {
+            Transform resolvedTarget = Target;
+            if (resolvedTarget == null)
+            {
+                return;
+            }
+
+            resolvedTarget.position = ResolvePosition();
+        }
+
+        private Vector3 ResolvePosition()
+        {
+            ResolveAxes(out Vector3 horizontal, out Vector3 vertical);
+
+            Vector3 originPosition = ResolveOriginPosition();
+            float horizontalOffset = _normalizedPosition.x * (Columns - 1) * _cellSize * 0.5f;
+            float verticalOffset = _normalizedPosition.y * (Rows - 1) * _cellSize * 0.5f;
+
+            return originPosition + _originOffset + (horizontal * horizontalOffset) + (vertical * verticalOffset);
+        }
+
+        private Vector3 ResolveOriginPosition()
+        {
+            if (_origin != null)
+            {
+                return _origin.position;
+            }
+
+            if (!_hasFallbackOriginPosition)
+            {
+                CaptureFallbackOriginPosition();
+            }
+
+            return _fallbackOriginPosition;
+        }
+
+        private void CaptureFallbackOriginPosition()
+        {
+            ResolveAxes(out Vector3 horizontal, out Vector3 vertical);
+
+            float horizontalOffset = _normalizedPosition.x * (Columns - 1) * _cellSize * 0.5f;
+            float verticalOffset = _normalizedPosition.y * (Rows - 1) * _cellSize * 0.5f;
+
+            Transform resolvedTarget = Target;
+            Vector3 targetPosition = resolvedTarget != null ? resolvedTarget.position : transform.position;
+            _fallbackOriginPosition = targetPosition - _originOffset - (horizontal * horizontalOffset) - (vertical * verticalOffset);
+            _hasFallbackOriginPosition = true;
+        }
+
+        private void ResolveAxes(out Vector3 horizontal, out Vector3 vertical)
+        {
+            horizontal = ResolveAxis(_horizontalAxis, Vector3.right);
+            vertical = ResolveAxis(_verticalAxis, Vector3.up);
+        }
+
+        private Vector3 ResolveAxis(Vector3 axis, Vector3 fallback)
+        {
+            Vector3 resolved = axis.sqrMagnitude > 0.00001f ? axis.normalized : fallback;
+            if (_useOriginRotation && _origin != null)
+            {
+                resolved = _origin.TransformDirection(resolved);
+            }
+
+            return resolved.normalized;
+        }
+
+        private void ClampCell()
+        {
+            _column = Mathf.Clamp(_column, 0, Columns - 1);
+            _row = Mathf.Clamp(_row, 0, Rows - 1);
+        }
+
+        private Vector2 CellToNormalizedPosition(int column, int row)
+        {
+            float normalizedX = Columns > 1 ? Mathf.Lerp(-1f, 1f, column / (float)(Columns - 1)) : 0f;
+            float normalizedY = Rows > 1 ? Mathf.Lerp(-1f, 1f, row / (float)(Rows - 1)) : 0f;
+            return new Vector2(normalizedX, normalizedY);
+        }
+
+        private void OnDrawGizmos()
+        {
+            DrawDebugGizmos(0.25f);
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            DrawDebugGizmos(1f);
+        }
+
+        private void DrawDebugGizmos(float alphaScale)
+        {
+            if (!_drawGizmos)
+            {
+                return;
+            }
+
+            ResolveAxes(out Vector3 horizontal, out Vector3 vertical);
+            Vector3 originPosition = ResolveOriginPosition();
+            Vector3 center = originPosition + _originOffset;
+            float width = (Columns - 1) * _cellSize;
+            float height = (Rows - 1) * _cellSize;
+            Vector3 bottomLeft = center - (horizontal * width * 0.5f) - (vertical * height * 0.5f);
+
+            Gizmos.color = WithAlpha(_gizmoColor, _gizmoColor.a * alphaScale);
+            for (int column = 0; column < Columns; column++)
+            {
+                Vector3 start = bottomLeft + (horizontal * column * _cellSize);
+                Gizmos.DrawLine(start, start + (vertical * height));
+            }
+
+            for (int row = 0; row < Rows; row++)
+            {
+                Vector3 start = bottomLeft + (vertical * row * _cellSize);
+                Gizmos.DrawLine(start, start + (horizontal * width));
+            }
+
+            Gizmos.DrawWireSphere(ResolvePosition(), _cellSize * 0.12f);
+        }
+
+        private static Color WithAlpha(Color color, float alpha)
+        {
+            color.a = Mathf.Clamp01(alpha);
+            return color;
+        }
+    }
+}

--- a/Samples~/IK/Scripts/IKDemoTargetGrid.cs.meta
+++ b/Samples~/IK/Scripts/IKDemoTargetGrid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b92252dcd0b44b9f94ad6f4a77d2bff9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
       "displayName": "Object Pooling",
       "description": "Sample showing single-prefab pooling with GameObjectPoolHandle and multi-prefab pooling with GameObjectPoolRegistry.",
       "path": "Samples~/ObjectPooling"
+    },
+    {
+      "displayName": "IK",
+      "description": "Sample scripts and setup notes for testing TwoBoneIK, FABRIKChain, AimIK, and GroundProbe with runtime grid controls.",
+      "path": "Samples~/IK"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Provide a small, drop-in set of IK solvers and helpers for rapid prototyping of procedural rigs and gameplay mechanics.
- Favor extremely simple setup, readability, and immediate usability with minimal configuration and no external dependencies.
- Deliver strong debug visualization and clear inspector tooltips while intentionally avoiding full-body/VR/animator integration or heavy tooling.

### Description
- Add a new `Runtime/IK` folder and namespace `jlinkdev.UnityUtilities.IK` with self-contained MonoBehaviour components: `TwoBoneIK`, `FABRIKChain`, `AimIK`, `GroundProbe`, `RotationLimit`, and visual helpers `IKTarget` and `PoleHint`.
- Add internal utility `IKMath` for small reusable math helpers (`ClampWeight`, `ProjectOntoPlane`, `SafeLookRotation`, `SumLengths`).
- Each solver exposes a `Solve()` method, defaults to automatic solving in `LateUpdate`, supports weight-based blending, handles unreachable targets gracefully, and exposes simple gizmo toggles and selected-mode visualizations for chain, target, reach, pole, and aim directions.
- Update `README.md` with a concise IK module section that states purpose, non-goals, quick setup examples for `TwoBoneIK`/`FABRIKChain`/`AimIK`/`GroundProbe`, notes on `LateUpdate` timing, and known limitations.

### Testing
- Inspected the repository file list with `rg --files` and validated `README.md` content using `cat README.md` and `nl -ba README.md`, which showed the new IK section and created files.
- Verified the presence and readability of created source files `Runtime/IK/*.cs` via file listing and `nl`, and these checks succeeded.
- No automated unit tests were added for this lightweight prototype module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62f4cb2848320bcef07d5d19ac89c)